### PR TITLE
Refactor datasets

### DIFF
--- a/openproblems/__init__.py
+++ b/openproblems/__init__.py
@@ -3,6 +3,7 @@ from . import tasks
 from . import tools
 from . import utils
 from .version import __version__
+from . import datasets
 
 import logging as _logging
 

--- a/openproblems/datasets/__init__.py
+++ b/openproblems/datasets/__init__.py
@@ -1,0 +1,3 @@
+import openproblems.datasets.functions
+import openproblems.datasets.loaders
+from openproblems.datasets.datasets import multimodal

--- a/openproblems/datasets/callbacks/_utils.py
+++ b/openproblems/datasets/callbacks/_utils.py
@@ -1,0 +1,120 @@
+import re
+from functools import partial, singledispatchmethod
+from hashlib import md5
+from io import BufferedIOBase
+from mimetypes import guess_type
+from os import PathLike
+from types import FunctionType, BuiltinFunctionType, MethodType, BuiltinMethodType
+from typing import Callable, Union, Iterable, Any, Hashable, Optional
+
+
+def _hash_function(fn: Callable, hasher: md5, *, encoding: str = "utf-8") -> None:
+    def _is_pure_function(fn) -> bool:
+        # `callable` not used because it would also catch our callback class + junk like classes
+        return isinstance(fn, (FunctionType, BuiltinFunctionType, MethodType, BuiltinMethodType))
+
+    def _hash_keys(ks: Union[str, Iterable[str]]) -> None:
+        if isinstance(ks, str):
+            ks = (ks,)
+
+        for k in ks:
+            hasher.update(k.encode(encoding))
+
+    def _hash_values(vs: Iterable[Any]) -> None:
+        for v in vs:
+            if _is_pure_function(v):
+                _hash_function(v, hasher, encoding=encoding)
+            elif not isinstance(v, Hashable):
+                hasher.update(repr(v).encode(encoding))
+            else:
+                h = hash(v)
+                hasher.update(h.to_bytes((h.bit_length() + 7) // 8, byteorder="little"))
+
+    try:
+        code = fn.__code__
+        hasher.update(code.co_code)
+        _hash_keys(code.co_name)
+        _hash_keys(code.co_filename)
+        _hash_keys(code.co_names)
+        _hash_values(code.co_consts)
+    except AttributeError:
+        if isinstance(fn, partial):
+            # WARNING: stuff like partial(lambda x: 1, 3) and partial(lambda x: 1, x=3) will hash to different values
+            _hash_function(fn.func, hasher, encoding=encoding)
+            _hash_values(fn.args)
+            _hash_keys(fn.keywords.keys())
+            _hash_values(fn.keywords.values())
+        else:
+            hasher.update(repr(fn).encode(encoding))
+
+
+class MimeType:
+    try:
+        from magic import Magic
+        _m = Magic(mime=True, uncompress=True)
+    except ImportError:
+        _m = None
+
+    _pat = re.compile(r"^(?P<type>\w+|\*)/(?P<tree>x(\.|-)|vnd\.|prs\.|.??)(?P<sub>\w+(-\w+)*|\*|)")
+
+    # TODO: fix the type
+    @classmethod
+    def get(cls, obj: "FP_t") -> Optional[str]:
+        mimetype = cls()._get(obj)
+        if mimetype is None:
+            return None
+
+        match = cls._pat.match(mimetype)
+        if match is None:
+            # possibly malformed, don't care
+            return mimetype
+
+        # normalize
+        return f"{match['type']}/{match['tree'].lower().replace('-', '.')}{match['sub']}"
+
+    # TODO: fix the type
+    @singledispatchmethod
+    def _get(self, obj: "FP_t") -> Optional[str]:
+        raise NotImplementedError(type(obj))
+
+    @_get.register(str)
+    @_get.register(PathLike)
+    def _(self, path: PathLike) -> Optional[str]:
+        try:
+            if self._m is not None:
+                return self._m.from_file(path)
+        except OSError:
+            pass
+        except Exception:
+            try:
+                guess_type(path)
+            except Exception:
+                pass
+
+    @classmethod
+    @_get.register
+    def _(self, fp: BufferedIOBase) -> Optional[str]:
+        # if we were to surely use BytesIO, we could just get a part of the buffer and delegat to `bytes`
+        try:
+            # seek/tell will throw UnsupportedError, which is a subclass of OSError
+            ix = fp.tell()
+            fp.seek(0)
+        except OSError:
+            return
+
+        try:
+            if self._m is not None:
+                return self._m.from_buffer(fp.read(8196))
+        except Exception:
+            pass
+        finally:
+            fp.seek(ix)
+
+    @classmethod
+    @_get.register
+    def _(self, fp: bytes) -> Optional[str]:
+        try:
+            if self._m is not None:
+                return self._m.from_buffer(fp)
+        except Exception:
+            pass

--- a/openproblems/datasets/callbacks/callback.py
+++ b/openproblems/datasets/callbacks/callback.py
@@ -1,0 +1,61 @@
+from hashlib import md5
+from typing import Callable, Any, Union, Optional
+
+from io import BufferedIOBase
+from os import PathLike
+from urllib.error import HTTPError
+
+from openproblems.datasets.callbacks._utils import _hash_function
+
+PATH_CB_t = Callable[[Union[str, PathLike]], Any]
+BUFF_CB_t = Callable[[BufferedIOBase], Any]
+CB_t = Union[BUFF_CB_t, PATH_CB_t]
+FP_t = Union[str, bytes, BufferedIOBase, PathLike]
+
+from openproblems.datasets.exceptions import CallbackError  # TODO: move me
+from openproblems.datasets.callbacks.exceptions import CallbackOSError, CallbackHTTPError  # TODO: or rather move me
+
+
+class FunctionHasherMixin:
+
+    def __init__(self):
+        self._hash: Optional[int] = None
+
+    def _create_hash(self, fn: Callable) -> int:
+        if self._hash is None:
+            hasher = md5()
+            _hash_function(fn, hasher)
+            self._hash = int(hasher.hexdigest(), base=16)
+
+        return self._hash
+
+
+class Callback(FunctionHasherMixin):
+
+    def __init__(self, callback: CB_t):
+        super().__init__()
+        if not callable(callback):
+            raise TypeError(type(callback))
+        self._callback = callback
+
+    def __hash__(self) -> int:
+        return self._create_hash(self._callback)
+
+    def __eq__(self, other) -> bool:
+        return type(self) == type(other) and hash(self) == hash(other)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return self._callback(*args, **kwargs)
+        except OSError as e:
+            raise CallbackOSError(self) from e
+        except HTTPError as e:
+            raise CallbackHTTPError(self) from e
+        except Exception as e:
+            raise CallbackError(self) from e
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}[callback={self._callback}]>"
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/openproblems/datasets/callbacks/constants.py
+++ b/openproblems/datasets/callbacks/constants.py
@@ -1,0 +1,11 @@
+from enum import Enum, auto
+
+
+class CallbackErrorPolicy(Enum):
+    RAISE = auto()
+    TRY_REST = auto()
+
+
+class CallbackResolutionPolicy(Enum):
+    PREFER_INFERRED = auto()
+    PREFER_SUPPLIED = auto()

--- a/openproblems/datasets/callbacks/exceptions.py
+++ b/openproblems/datasets/callbacks/exceptions.py
@@ -1,0 +1,10 @@
+from urllib3.exceptions import HTTPError
+from openproblems.datasets.exceptions import DatasetError
+
+
+class CallbackOSError(DatasetError, OSError):
+    pass
+
+
+class CallbackHTTPError(DatasetError, HTTPError):
+    pass

--- a/openproblems/datasets/callbacks/registry.py
+++ b/openproblems/datasets/callbacks/registry.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+from functools import partial
+from types import MappingProxyType
+from typing import Mapping, Mapping as TMapping, Iterable, Iterator
+
+import pandas as pd
+from anndata import read_h5ad as aread
+from openproblems.datasets.callbacks.callback import CB_t, Callback
+from scanpy import read as sread
+
+
+class CallBackRegistry(Mapping, ABC):
+    def __init__(self, data: TMapping[str, CB_t] = MappingProxyType({})):
+        super().__init__()
+        self._container = MappingProxyType({k:(Callback(v) if not isinstance(v, Callback) else v)
+                                            for k, v in data.items()})
+        for k, v in self._container.items():
+            if not callable(v):  # check `callable` rather than our type (more future-proof)
+                raise TypeError(f"Callback `{v}` registered for MIME `{k}` is not callable.")
+
+    def sort_closest_to(self, v: Callback) -> Iterable[Callback]:
+        # TODO: make something smarter
+        return (cb for cb in self.values() if cb != v)
+
+    def __getitem__(self, k: str) -> Callback:
+        if k not in self._container:
+            return self.__missing__(k)
+        return self._container[k]
+
+    def __contains__(self, k: str) -> bool:
+        return k in self._container
+
+    def __missing__(self, k: str) -> Callback:
+        return self._default_callback
+
+    def __len__(self) -> int:
+        return len(self._container)
+
+    def __iter__(self) -> Iterator["str"]:
+        return iter(self._container)
+
+    def __repr__(self) -> str:
+        return repr(self._container)
+
+    def __str__(self) -> str:
+        return str(self._container)
+
+    @property
+    @abstractmethod
+    def _default_callback(self):
+        pass
+
+
+class FileCallbackRegistry(CallBackRegistry):
+    @property
+    def _default_callback(self):
+        return sread
+
+
+class BufferCallbackRegistry(CallBackRegistry):
+    @property
+    def _default_callback(self):
+        return aread
+
+
+FILE_REG = FileCallbackRegistry({
+    "text/comma-separated-values": pd.read_csv,
+    "text/csv": pd.read_csv,
+    "text/tab-separated-values": partial(pd.read_csv, sep="\t"),
+    "text/tsv": partial(pd.read_csv, sep="\t"),
+    "application/x-hdf5": sread,  # does not support file-like objects, only paths
+})
+BUFF_REG = BufferCallbackRegistry({
+    "text/comma-separated-values": pd.read_csv,
+    "text/csv": pd.read_csv,
+    "text/tab-separated-values": partial(pd.read_csv, sep="\t"),
+    "text/tsv": partial(pd.read_csv, sep="\t"),
+    "application/x-hdf5": aread,  # does support file-like objects
+})

--- a/openproblems/datasets/datasets/__init__.py
+++ b/openproblems/datasets/datasets/__init__.py
@@ -1,0 +1,1 @@
+import openproblems.datasets.datasets.multimodal

--- a/openproblems/datasets/datasets/dataset.py
+++ b/openproblems/datasets/datasets/dataset.py
@@ -1,0 +1,117 @@
+from abc import ABC
+from anndata import AnnData
+from openproblems.datasets.events.constants import Event, EventPriority
+from openproblems.datasets.events.event_manager import PipeEventManager
+from openproblems.datasets.exceptions import EmptyListenerError
+from openproblems.datasets.loaders.loader import RemoteURLDownloader
+from openproblems.exceptions import SCOPException
+from openproblems.datasets.functions.processors import NoopProcessor
+from openproblems.datasets.functions.samplers import SizedSampler
+from openproblems.datasets.functions.validators import IsAnnData
+
+
+def _(error: Exception, fn):
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            raise error from e
+
+    return wrapper
+
+
+# TODO: add the metaclass, checking all fields and converting some fields
+class DatasetABC(ABC):
+    METADATA = None
+
+    _DOWNLOADER = RemoteURLDownloader()
+    _PROCESSOR = NoopProcessor()
+    _SAMPLER = SizedSampler(size=500, cells=True) >> SizedSampler(500, cells=False)
+    _VERIFIER = IsAnnData()
+
+    _event_manager = PipeEventManager()
+
+    def __init_subclass__(cls):
+        cls.__initialize__()
+
+    @classmethod
+    def __initialize__(cls):
+        pass
+        # TODO: NYI
+        # cls._event_manager.register(Event.CACHE_LOAD, ..., id="fetch-cache-data", priority=0)
+        # cls._event_manager.register(Event.CACHE_STORE, ..., id="store-cache-data", priority=0)
+
+    # TODO: different design:
+    # make this a classmethod, returning some wrapper around anndata with 1 method (sample)
+    # move the sampler to that method (descriptor most likely to downloader - to allow re-downloader)
+    # alt:
+    # register a file cache AND a memory cache (emit_first) for load (prioritize memcache), but emit for store
+    # alt: use singleton objects
+    def load(self, **kwargs) -> AnnData:
+        url = self.METADATA.url
+        # TODO: see __initialize__
+        # data = _(SCOPException("Pre download error."))(self._event_manager.emit_first(Event.CACHE_LOAD, url))
+        data = None
+
+        if data is None:
+            data = _(SCOPException("Download error."), self._event_manager.emit_first)(Event.DOWNLOAD, url, **kwargs)
+            if not isinstance(url, str):  # multiple urls, need to combine them
+                # TODO: maybe let _process handle it?
+                data = _(SCOPException("Post download error."), self._event_manager.emit_first)(Event.POST_DOWNLOAD, data)
+            data = self._process(data)
+
+        self._verify(data)
+
+        return data
+
+    def sample(self, data: AnnData) -> AnnData:
+        try:
+            return self._verify(self._event_manager.emit_first(Event.SAMPLE, data))
+        except EmptyListenerError:  # TODO: NYI
+            raise  # TODO
+        except SCOPException:
+            raise
+        except Exception as e:
+            raise SCOPException("Sampling error.") from e
+
+    def _process(self, data: AnnData) -> AnnData:
+        try:
+            data = self._event_manager.emit(Event.PROCESS, data)  # custom, class-specific processors
+            # TODO: see __initialize__
+            # self._event_manager.emit_first(Event.CACHE_STORE, data)
+        except EmptyListenerError:  # TODO: NYI
+            return data
+        except SCOPException:
+            raise
+        except Exception as e:
+            raise SCOPException("Processing error") from e
+
+        return data
+
+    def _verify(self, data: AnnData) -> AnnData:
+        try:
+            self._event_manager.emit(Event.VERIFY, data)
+        except EmptyListenerError:  # TODO: NYI
+            pass
+        except SCOPException:
+            raise
+        except Exception as e:
+            raise SCOPException("Unknown verification error.") from e
+
+        return data
+
+
+# TODO: metaclass to verify attributes are present and/or transform them (URL class + Function class)
+class Dataset(DatasetABC):
+
+    @classmethod
+    def __initialize__(cls):
+        super().__initialize__()
+        cls._event_manager.register(Event.DOWNLOAD, cls._DOWNLOADER.download, id="default-download", priority=EventPriority.MEDIUM)
+        cls._event_manager.register(Event.PROCESS, cls._PROCESSOR, id="default-processor", priority=EventPriority.MEDIUM)
+        cls._event_manager.register(Event.VERIFY, cls._VERIFIER, id="default-verify", priority=EventPriority.MEDIUM)
+        cls._event_manager.register(Event.SAMPLE, cls._SAMPLER, id="default-sample", priority=EventPriority.MEDIUM)
+
+    # TODO: should DL be combined - not really
+    # TODO: but URLs should have fallbacks (nonrec) to try (might need emit_first_noerror)
+

--- a/openproblems/datasets/datasets/multimodal.py
+++ b/openproblems/datasets/datasets/multimodal.py
@@ -1,0 +1,24 @@
+from openproblems.datasets.datasets.dataset import Dataset
+from openproblems.datasets.functions import SizedSampler, GroupBalancedSampler
+from openproblems.datasets.functions import RemoveEmpty
+from openproblems.datasets.metadata import Metadata
+
+
+__all__ = ["Zebrafish"]
+
+
+# TODO: metaclass will handle custom functions
+class Zebrafish(Dataset):
+    METADATA = Metadata(
+        name="Zebrafish",
+        author="Foo",
+        year=2016,
+        url="https://ndownloader.figshare.com/files/24566651?private_link=e3921450ec1bd0587870"
+    )
+    _SAMPLER = (
+        GroupBalancedSampler(keys="lab", sampler=SizedSampler(500, cells=True)) >>
+        RemoveEmpty() >>
+        SizedSampler(100, cells=False) >>
+        RemoveEmpty()
+    )
+    # it either inherits parent's processor/verifier/downloader or completely overrides it

--- a/openproblems/datasets/events/constants.py
+++ b/openproblems/datasets/events/constants.py
@@ -1,0 +1,35 @@
+from enum import Enum, auto, IntEnum
+
+
+class NoValue(Enum):
+    def __repr__(self):
+        return f"<{self.__class__.__name__}.{self.name}>"
+
+
+class Event(NoValue):
+    CACHE_LOAD = auto()
+    CACHE_STORE = auto()
+    DOWNLOAD = auto()
+    POST_DOWNLOAD = auto()
+    PROCESS = auto()
+    VERIFY = auto()
+    SAMPLE = auto()
+
+    # currently unused
+    EVENT_GATHER = auto()
+    EVENT_GATHER_TRANSFORM = auto()
+
+
+class AutoPriority(IntEnum):
+    def __new__(cls):
+        value = len(cls.__members__) + 4 + 1  # 4 is just an offset so that we don't start from 0
+        obj = int.__new__(cls, 2 ** value)
+        obj._value_ = 2 ** value
+        return obj
+
+
+class EventPriority(AutoPriority):
+    ULTRA = ()
+    HIGH = ()
+    MEDIUM = ()
+    LOW = ()

--- a/openproblems/datasets/events/event_manager.py
+++ b/openproblems/datasets/events/event_manager.py
@@ -1,0 +1,114 @@
+from abc import ABC, abstractmethod
+from functools import total_ordering
+from typing import Callable, Any, Optional, List
+from collections import defaultdict
+from openproblems.datasets.callbacks.callback import Callback
+import joblib as jl
+from openproblems.datasets.events.constants import Event, EventPriority
+
+
+@total_ordering
+class EventHandler(Callback):
+
+    def __init__(self, callback, id: Any, priority: int):
+        super().__init__(callback)
+
+        self._id = id
+        self._priority = priority
+
+    @property
+    def id(self) -> Any:
+        return self._id
+
+    @property
+    def priority(self) -> int:
+        return self._priority
+
+    def __lt__(self, other: "EventHandler") -> bool:
+        if not isinstance(other, EventHandler):
+            return NotImplemented
+        return self.priority < other.priority
+
+    def __eq__(self, other: object) -> bool:
+        return super().__eq__(other) and self.priority == other.priority
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}[id={self.id}, priority={self.priority}, callback={self._callback}]>"
+
+    def __str__(self) -> str:
+        return repr(self)
+
+
+class EventManagerABC(ABC):
+
+    def __init__(self):
+        self._handlers = defaultdict(list)
+
+    def register(self, event: Event, callback: Callable[[Any], Any], id: Any, priority: int) -> "EventManagerABC":
+        event = Event(event)
+        self._handlers[event].append(EventHandler(callback=callback, id=id, priority=priority))
+
+        return self
+
+    def deregister(self, event: Event, id: Any) -> "EventManagerABC":
+        event = Event(event)
+        self._handlers[event] = [h for h in self._handlers[event] if h.id != id]
+
+        return self
+
+    def prioritize(self, event: Event, id: Any, new_priority: int) -> "EventManagerABC":
+        return NotImplemented
+
+    def handlers(self, event: Event) -> List[EventHandler]:
+        return sorted(self._handlers[event])
+
+    @abstractmethod
+    def emit(self, event: Event, *args, **kwargs):
+        pass
+
+    def emit_first(self, event: Event, *args, **kwargs):
+        for handler in self.handlers(event):
+            res = handler(*args, **kwargs)
+            if res is not None:
+                return res
+
+
+class PipeEventManager(EventManagerABC):
+    def emit(self, event: Event, *args, **kwargs):
+        handlers = self.handlers(event)
+        if not len(args):
+            raise ValueError()
+
+        if not len(handlers):
+            return None
+
+        result = handlers[0](*args, **kwargs)
+        args = args[1:]
+        print(result)
+
+        for handler in handlers[1:]:
+            result = handler(result, *args, **kwargs)
+
+        return result
+
+
+# TODO: not used
+class ScatterGatherEventManager(EventManagerABC):
+    def __init__(self, n_jobs: Optional[int] = None, backend: str = "loky"):
+        super().__init__()
+
+        if n_jobs is not None and n_jobs == 0:
+            raise ValueError()
+
+        self._n_jobs = n_jobs
+        self._backend = backend
+
+        self.register(Event.EVENT_GATHER, lambda _: _, id="gather-identity", priority=EventPriority.MEDIUM)
+        self.register(Event.EVENT_GATHER_TRANSFORM, lambda _: _, id="gather-transform-identity", priority=EventPriority.MEDIUM)
+
+    def emit(self, event: Event, *args, **kwargs):
+        res = jl.Parallel(n_jobs=self._n_jobs, backend=self._backend)(jl.delayed(h)(*args, **kwargs)
+                                                                      for h in self.handlers(event))
+
+        res = self.emit_first(Event.EVENT_GATHER, res)
+        return self.emit_first(Event.EVENT_GATHER_TRANSFORM, res)

--- a/openproblems/datasets/events/event_manager.py
+++ b/openproblems/datasets/events/event_manager.py
@@ -84,7 +84,6 @@ class PipeEventManager(EventManagerABC):
 
         result = handlers[0](*args, **kwargs)
         args = args[1:]
-        print(result)
 
         for handler in handlers[1:]:
             result = handler(result, *args, **kwargs)

--- a/openproblems/datasets/events/exception.py
+++ b/openproblems/datasets/events/exception.py
@@ -1,0 +1,1 @@
+from openproblems.datasets.exceptions import DatasetError

--- a/openproblems/datasets/exceptions.py
+++ b/openproblems/datasets/exceptions.py
@@ -1,0 +1,15 @@
+from openproblems.exceptions import SCOPException
+
+
+class DatasetError(SCOPException):
+    pass
+
+
+# TODO: move me
+class CallbackError(DatasetError, RuntimeError):
+    pass
+
+
+# TODO: move me
+class EmptyListenerError(SCOPException, ValueError):
+    pass

--- a/openproblems/datasets/functions/__init__.py
+++ b/openproblems/datasets/functions/__init__.py
@@ -1,0 +1,4 @@
+from openproblems.datasets.functions.processors import NoopProcessor, MakeUnique, Sparsify, UnifyDtypes, Categorize, \
+    RemoveEmpty
+from openproblems.datasets.functions.validators import ObjectTypeValidator, ColumnTypeValidator, IsAnnData
+from openproblems.datasets.functions.samplers import ValueSampler, SizedSampler, RandomSampler, GroupBalancedSampler

--- a/openproblems/datasets/functions/_utils.py
+++ b/openproblems/datasets/functions/_utils.py
@@ -1,0 +1,61 @@
+from types import FunctionType, MethodType, BuiltinFunctionType, BuiltinMethodType
+from typing import Iterable, Optional, Type, Union, Tuple, Callable, Mapping, Any
+
+import builtins
+import numpy as np
+from pandas.core.dtypes.common import infer_dtype_from_object
+from scipy.sparse import spmatrix, csr_matrix, issparse
+from inspect import isclass
+
+
+builtin_types = tuple(getattr(builtins, d) for d in dir(builtins) if isinstance(getattr(builtins, d), type))
+
+
+def _is_function(fn):
+    return isinstance(fn, FunctionType) or isinstance(fn, MethodType) or \
+           isinstance(fn, BuiltinFunctionType) or isinstance(fn, BuiltinMethodType)
+
+
+def _validate_types(types: Iterable[Optional[Type]], *,
+                    allow_none: bool = False,
+                    valid_types: Union[Type, Tuple[Type, ...]] = type) -> None:
+    for typ in types:
+        if typ is None:
+            if not allow_none:
+                raise ValueError()
+            continue
+        if not isinstance(typ, valid_types):
+            raise TypeError(type(typ))
+
+
+def _get_types(typ: Optional[Union[str, Callable, type]]) -> Union[Callable[[Any], bool], np.dtype, type]:
+    if typ is None:
+        return lambda _: True
+    if _is_function(typ):
+        return typ  # TODO and a warning: the callbacks are called on the object, not the dtype
+    if typ in builtin_types:
+        return typ
+    if isclass(typ) and issubclass(typ, type):
+        return typ
+    return infer_dtype_from_object(typ)  # get a numpy-like dtype
+
+
+def _maybe_to_sparse_matrix(arr: Union[np.ndarray, spmatrix], cls: Type[spmatrix] = csr_matrix) -> Union[np.ndarray, spmatrix]:
+    if issparse(arr):
+        if not isinstance(arr, cls):
+            return cls(arr)
+
+    if np.issubdtype(arr.dtype, np.integer):
+        return cls(arr)
+
+    # TODO: logg
+
+    return arr
+
+
+def _maybe_convert_dtype(arr: np.ndarray, dtype_map: Mapping[np.dtype, np.dtype]) -> np.ndarray:
+    for old_type, new_type in dtype_map.items():
+        if np.issubdtype(arr.dtype, old_type):
+            return arr.astype(new_type, copy=False)
+
+    return arr

--- a/openproblems/datasets/functions/base.py
+++ b/openproblems/datasets/functions/base.py
@@ -1,0 +1,46 @@
+from typing import Callable, Any
+from anndata import AnnData
+from abc import ABC, abstractmethod
+
+
+# TODO: rename to callbacks
+class FunctionBase(ABC):
+    def __rshift__(self, other: "FunctionBase") -> "FComposition":
+        from openproblems.datasets.functions.composition import FComposition
+
+        if not isinstance(other, FunctionBase):
+            return NotImplemented
+
+        left_fns = self._funcs if isinstance(self, FComposition) else [self]
+        right_fns = self._funcs if isinstance(other, FComposition) else [other]
+
+        return FComposition(left_fns + right_fns)
+
+    @classmethod
+    def from_callable(cls, fn: Callable[[AnnData], Any]) -> "FunctionBase":
+        if isinstance(fn, cls):
+            return fn
+        if not callable(fn):
+            raise TypeError()
+        # TODO
+        if not cls._validate_signature(fn):
+            raise ValueError()
+
+        return SimpleFunction(fn)
+
+    @classmethod
+    def _validate_signature(cls, fn: Callable[[AnnData], Any]) -> bool:
+        # TODO: introduce expected signature
+        pass
+
+    @abstractmethod
+    def __call__(self, *args, **kwargs) -> Any:
+        pass
+
+
+class SimpleFunction(FunctionBase):
+    def __init__(self, fn: Callable[[AnnData], Any]):
+        self._fn = fn
+
+    def __call__(self, data: AnnData, **kwargs) -> Any:
+        return self._fn(data, **kwargs)

--- a/openproblems/datasets/functions/composition.py
+++ b/openproblems/datasets/functions/composition.py
@@ -1,0 +1,35 @@
+from functools import singledispatchmethod
+from typing import Sequence, Any
+
+from anndata import AnnData
+from openproblems.datasets.functions.base import FunctionBase
+from openproblems.datasets.functions.samplers import SamplerFunction
+from openproblems.datasets.functions.processors import ProcessorFunction
+from openproblems.datasets.functions.validators import ValidatorFunction
+
+
+class FComposition(FunctionBase):
+    def __init__(self, funcs: Sequence[FunctionBase]):
+        # TODO: verify signatures
+        assert len(funcs) >= 2
+        self._funcs = funcs
+
+    def __call__(self, data: AnnData, **kwargs) -> Any:
+        for fn in self._funcs:
+            data = self._handle_result(fn, data, fn(data, **kwargs))
+        return data
+
+    @singledispatchmethod
+    def _handle_result(self, mixin: "FunctionBase", data: AnnData, result: Any) -> Any:
+        raise NotImplementedError(mixin)
+
+    @_handle_result.register(ProcessorFunction)
+    @_handle_result.register(SamplerFunction)
+    def _(self, _mixin: "FunctionBase", _data: AnnData, result: AnnData) -> Any:
+        return result
+
+    @_handle_result.register(ValidatorFunction)
+    def _(self, mixin: "FunctionBase", data: AnnData, result: bool) -> Any:
+        if not result:
+            raise RuntimeError("Validator failed:", mixin)  # TODO: custom exception
+        return data

--- a/openproblems/datasets/functions/exceptions.py
+++ b/openproblems/datasets/functions/exceptions.py
@@ -1,0 +1,1 @@
+from openproblems.datasets.exceptions import DatasetError

--- a/openproblems/datasets/functions/processors.py
+++ b/openproblems/datasets/functions/processors.py
@@ -1,0 +1,119 @@
+from abc import ABC
+
+from typing import Optional, Union, Type, Sequence, Any
+
+from pandas.core.dtypes.common import is_integer_dtype, is_bool_dtype, is_object_dtype, is_string_dtype, \
+    is_categorical_dtype, is_signed_integer_dtype, is_unsigned_integer_dtype, is_float_dtype
+from scipy.sparse import spmatrix, csr_matrix
+from openproblems.datasets.functions.base import FunctionBase
+from openproblems.datasets.functions._utils import _maybe_to_sparse_matrix, _maybe_convert_dtype
+from anndata import AnnData
+import scanpy as sc
+import numpy as np
+
+
+__all__ = ["NoopProcessor", "MakeUnique", "Sparsify", "UnifyDtypes", "Categorize"]
+
+
+class ProcessorFunction(FunctionBase, ABC):
+    pass
+
+
+class NoopProcessor(ProcessorFunction):
+    def __call__(self, adata: AnnData) -> AnnData:
+        return adata
+
+
+class MakeUnique(ProcessorFunction):
+    def __call__(self, adata: AnnData) -> AnnData:
+        adata.obs_names_make_unique()
+        adata.var_names_make_unique()
+        return adata
+
+
+class RemoveEmpty(ProcessorFunction):
+    def __call__(self, data: AnnData) -> AnnData:
+        sc.pp.filter_cells(data)
+        sc.pp.filter_genes(data)
+        return data
+
+
+class Sparsify(ProcessorFunction):
+    def __init__(self, X: bool = True, layers: Optional[Sequence[str]] = None, raw: bool = True,
+                 cls: Type[spmatrix] = csr_matrix):
+        super().__init__()
+        self._X = X
+        self._raw = raw
+        self._layers = layers
+        self._cls = cls
+
+    def __call__(self, data: AnnData) -> AnnData:
+        if self._X:
+            data.X = _maybe_to_sparse_matrix(data.X, cls=self._cls)
+
+        if self._raw:
+            if data.raw is not None:
+                data.raw._X = _maybe_to_sparse_matrix(data.raw.X, cls=self._cls)
+            else:
+                pass  # TODO: log
+
+        layers = data.layers.keys() if self._layers is None else self._layers
+
+        for layer in layers:
+            if layer in data.layers:
+                data.layers[layer] = _maybe_to_sparse_matrix(data.layers[layer], cls=self._cls)
+                pass
+            else:
+                pass  # TODO: log
+
+        return data
+
+
+class UnifyDtypes(ProcessorFunction):
+    def __init__(self, signed: np.dtype = np.int32, unsigned: np.dtype = np.uint32, floating: np.dtype = np.float64):
+        if not is_signed_integer_dtype(signed):
+            raise TypeError()
+        if not is_unsigned_integer_dtype(unsigned):
+            raise TypeError()
+        if not is_float_dtype(floating):
+            raise TypeError()
+
+        super().__init__()
+
+        self._dtype_map = {np.signedinteger: signed, np.unsignedinteger: unsigned, np.floating: floating}
+
+    def __call__(self, data: AnnData) -> AnnData:
+        data.X = _maybe_convert_dtype(data.X, self._dtype_map)
+        if data.raw is not None:
+            data.raw._X = _maybe_convert_dtype(data.raw.X, self._dtype_map)
+
+        for layer in data.layers:
+            data[layer] = _maybe_convert_dtype(data.layers[layer], self._dtype_map)
+
+        return data
+
+
+class Categorize(ProcessorFunction):
+    def __init__(self, key: Union[Any, Sequence[Any]]):
+        if isinstance(key, str):
+            key = (key,)
+        if not isinstance(key, Sequence):
+            raise TypeError()
+
+        self._keys = sorted(key)
+
+    def __call__(self, data: AnnData) -> AnnData:
+        for key in self._keys:
+            if key not in data.obs:
+                continue  # TODO: log
+            col = data.obs[key]
+
+            if not is_categorical_dtype(col):
+                if is_integer_dtype(col) or is_bool_dtype(col) or is_string_dtype(col) or is_object_dtype(col):
+                    data.obs[key] = col.astype("category").values
+                else:
+                    continue  # TODO: log
+
+            data.obs[key].cat.remove_empty_categories(inplace=True)
+
+        return data

--- a/openproblems/datasets/functions/samplers.py
+++ b/openproblems/datasets/functions/samplers.py
@@ -1,0 +1,199 @@
+from operator import __and__, __or__
+from functools import reduce
+from typing import Sequence, Callable, Optional, Union, Any
+from openproblems.datasets.functions.base import FunctionBase
+from anndata import AnnData
+from abc import ABC, abstractmethod
+from copy import copy
+
+import numpy as np
+import joblib as jl
+
+from pandas.core.dtypes.common import is_categorical_dtype
+
+
+def _optimize_index_sampler(fn: Callable, samplers: Sequence["SamplerFunction"]) -> Union["IndexSampler", Sequence[
+    "SamplerFunction"]]:
+    index_samplers = [s for s in samplers if isinstance(s, IndexSampler)]
+    other_samplers = [s for s in samplers if not isinstance(s, IndexSampler)]
+
+    assert len(index_samplers) + len(other_samplers) == len(samplers)
+
+    if len(index_samplers) <= 1:
+        return samplers
+
+    cell_index = [s for s in index_samplers if s._cells]
+    gene_index = [s for s in index_samplers if not s._cells]
+
+    if len(cell_index) >= 2:
+        dummy = copy(cell_index[0])
+        dummy._calculate_index = lambda self, data: reduce(fn, [s._calculate_cell_index(data) for s in cell_index])
+        new_cell_index = [dummy]
+    else:
+        new_cell_index = cell_index
+
+    if len(gene_index) >= 2:
+        dummy = copy(gene_index[0])
+        dummy._calculate_index = lambda self, data: reduce(fn, [s._calculate_cell_index(data) for s in gene_index])
+        new_gene_index = [dummy]
+    else:
+        new_gene_index = [dummy]
+
+    return new_cell_index + new_gene_index + other_samplers
+
+
+class SamplerFunction(FunctionBase, ABC):
+    def __init__(self, cells: Optional[bool] = True):
+        self._cells = cells
+
+    def __and__(self, other: "SamplerFunction"):
+        if not isinstance(other, SamplerFunction):
+            return NotImplemented
+
+        lsampler = self._samplers if isinstance(self, CombinedSampler) else [self]
+        rsampler = other._samplers if isinstance(other, CombinedSampler) else [other]
+
+        return AndCombiner(lsampler + rsampler)
+
+    def __or__(self, other: "SamplerFunction"):
+        if not isinstance(other, SamplerFunction):
+            return NotImplemented
+
+        lsampler = self._samplers if isinstance(self, CombinedSampler) else [self]
+        rsampler = other._samplers if isinstance(other, CombinedSampler) else [other]
+
+        return OrCombiner(lsampler + rsampler)
+
+    @abstractmethod
+    def _sample(self, data: AnnData) -> AnnData:
+        pass
+
+    def _pre_sample(self, data: AnnData, copy: bool = True):
+        if self._cells or self._cells is None:
+            return data.copy() if copy else data
+
+        if data.is_view:
+            data = data.copy()
+
+        return data.T
+
+    def _post_sample(self, data: AnnData):
+        if self._cells is None:
+            return data
+
+        data = data if self._cells else data.T
+        return data.copy() if data.is_view else data
+
+    def __call__(self, data: AnnData, copy: bool = True):
+        return self._post_sample(self._sample(self._pre_sample(data)))
+
+
+class CombinedSampler(SamplerFunction, ABC):
+    def __init__(self, samplers: Sequence[SamplerFunction], *, combiner: Callable, n_jobs: Optional[int] = None):
+        super().__init__(cells=None)
+        self._samplers = samplers
+        self._combiner = combiner
+        self._n_jobs = n_jobs
+
+    def _sample(self, data: AnnData) -> AnnData:
+        with jl.Parallel(n_jobs=self._n_jobs, prefer="processes") as par:
+            subsets = par(jl.delayed(sampler)(data, copy=True) for sampler in self._samplers)
+
+        obs_index = reduce(self._combiner, [subset.obs_name for subset in subsets], initial=data.obs_names)
+        var_index = reduce(self._combiner, [subset.var_names for subset in subsets], initial=data.var_names)
+
+        return data[obs_index, :][:, var_index]
+
+
+class AndCombiner(CombinedSampler):
+    def __init__(self, sampler: Sequence[SamplerFunction]):
+        super().__init__(sampler, combiner=__and__)
+
+
+class OrCombiner(CombinedSampler):
+    def __init__(self, sampler: Sequence[SamplerFunction]):
+        super().__init__(sampler, combiner=__or__)
+
+
+class IndexSampler(SamplerFunction):
+    def __init__(self, cells: bool = True):
+        super().__init__(cells)
+
+    def _sample(self, data: AnnData) -> AnnData:
+        # TODO: ignore invalid option?
+        data._inplace_subset_obs(self._calculate_index(data))
+        return data
+
+    @abstractmethod
+    def _calculate_index(self, data: AnnData):
+        pass
+
+
+class ValueSampler(IndexSampler):
+    def __init__(self, key: Any, values: Sequence[Any], *, cells: bool = True):
+        super().__init__(cells)
+
+        self._key = key
+        self._values = values
+
+    def _calculate_index(self, data: AnnData):
+        return np.isin(data.obs[self._key], self._values)
+
+
+class SizedSampler(IndexSampler):
+    def __init__(self, size: int, *, cells: bool = True):
+        super().__init__(cells)
+        self._size = size
+
+    def _calculate_index(self, data: AnnData):
+        return np.arange(self._size)
+
+
+class RandomSampler(SizedSampler):
+    def __init__(self, size: int, *, seed: Optional[int] = None, cells: bool = True):
+        super().__init__(size=size, cells=cells)
+        self._rs = np.random.RandomState(seed=seed)
+
+    def _calculate_index(self, data: AnnData):
+        return self._rs.choice(data.n_obs, size=self._size, replace=False)
+
+
+class GroupBalancedSampler(SamplerFunction):
+    def __init__(self, keys: Union[str, Sequence[str]], *, sampler: SamplerFunction, cells: bool = True):
+        super().__init__(cells=cells)
+        self._keys = list(sorted(set(keys)))
+        # TODO: cells are wrong
+        self._sampler = sampler
+
+    def _sample(self, data: AnnData) -> AnnData:
+        obs = data.obs[self._keys]
+        for col in obs.columns:
+            if not is_categorical_dtype(obs[col]):
+                raise TypeError(col)
+
+        gb = obs.groupby(self._keys)
+        subsets = []
+
+        for group in gb.groups.keys():
+            subset = data[(data.obs[self._keys] == group).all(1)]
+            subset = self._sampler(subset)
+
+            if subset.n_obs:
+                subsets.append(subset)
+            else:
+                print("TODO: Empty subset")
+
+        if not subsets:
+            raise RuntimeError("All subsets are empty.")
+
+        res = subsets[0].concatenate(*subsets[1:], batch_key=None)
+        for col in data.obs.columns:
+            if col in res.obs:
+                res.obs[col] = res.obs[col].astype(data.obs[col].dtype)
+        # TODO: remove -{batch_id} from index and keep batch index (but avoid overwrites)
+
+        res.uns = data.uns
+        res.varm = data.varm
+        res.varp = data.varp
+
+        return res

--- a/openproblems/datasets/functions/validators.py
+++ b/openproblems/datasets/functions/validators.py
@@ -1,0 +1,86 @@
+from openproblems.datasets.functions._utils import _validate_types, _get_types, _is_function
+from openproblems.datasets.functions.base import FunctionBase
+from anndata import AnnData
+from abc import ABC
+from typing import Tuple, Any, Type, Union, Iterable, Mapping, Optional, Callable, Sequence
+from scipy.sparse import spmatrix
+from pandas.core.dtypes.common import infer_dtype_from_object
+from types import MappingProxyType
+from enum import Enum
+import pandas as pd
+import numpy as np
+
+Type_t = Tuple[Union[Type, str,], ...]
+
+__all__ = ["ObjectTypeValidator", "ColumnTypeValidator", "IsAnnData"]
+
+
+class AttributeLoc(str, Enum):
+    OBS = "obs"
+    OBSM = "obsm"
+    VAR = "var"
+    VARM = "varm"
+    OBSP = "obsp"
+    UNS = "uns"
+
+
+class ValidatorFunction(FunctionBase, ABC):
+    pass
+
+
+class ObjectTypeValidator(ValidatorFunction):
+    def __init__(self, types: Union[Type, Tuple[Type, ...]]):
+        types = tuple(types) if isinstance(types, Iterable) else (types,)
+        _validate_types(types)
+
+        self._valid_types = types
+
+    def __call__(self, obj: Any) -> Any:
+        if not isinstance(obj, self._valid_types):
+            raise TypeError(type(obj))
+        return obj
+
+
+class ColumnTypeValidator(ValidatorFunction):
+    def __init__(self, types: Union[Sequence[Any], Mapping[Any, Optional[Type]]],
+                 location: Union[str, AttributeLoc] = AttributeLoc.OBS,
+                 exact: bool = True):
+        location = AttributeLoc(location)
+
+        if not isinstance(types, Mapping):
+            types = {typ: None for typ in types}
+        _validate_types(types.values(), allow_none=True, valid_types=(str, type, Callable))
+
+        self._type_map = MappingProxyType({k: _get_types(v) for k, v in types.items()})
+        self._location = location
+        self._exact = exact
+
+    def __call__(self, adata: AnnData) -> AnnData:
+        haystack = getattr(adata, self._location)
+        for colname, expected in self._type_map.items():
+            if expected is None:
+                continue
+
+            needle = haystack[colname]
+
+            if _is_function(expected):
+                # warning: this is called on the object to support pandas checks
+                res = expected(needle)
+            else:
+                if isinstance(needle, pd.Series):
+                    actual = infer_dtype_from_object(needle.dtype)
+                elif isinstance(needle, (np.ndarray, spmatrix)):
+                    actual = infer_dtype_from_object(needle)
+                else:
+                    actual = type(needle)
+                res = actual == expected if self._exact else issubclass(actual, expected)
+
+            if not res:
+                raise TypeError(colname, expected, actual)  # TODO: nicer message
+
+        return adata
+
+
+class IsAnnData(ObjectTypeValidator):
+    def __init__(self):
+        super().__init__(AnnData)

--- a/openproblems/datasets/loaders/__init__.py
+++ b/openproblems/datasets/loaders/__init__.py
@@ -1,0 +1,2 @@
+from openproblems.datasets.loaders.loader import LocalfileDownloader, RemoteURLDownloader
+from openproblems.datasets.loaders.sfaira_loader import SFAIRALoader

--- a/openproblems/datasets/loaders/loader.py
+++ b/openproblems/datasets/loaders/loader.py
@@ -1,0 +1,185 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Union, Any, Mapping, Sequence
+from functools import singledispatchmethod
+
+from openproblems.datasets.callbacks.constants import CallbackResolutionPolicy, CallbackErrorPolicy
+from openproblems.datasets.url import URL
+from requests import Request, Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+from urllib3.exceptions import HTTPError
+from io import BytesIO, BufferedIOBase
+from tqdm.auto import tqdm
+
+from os import PathLike
+
+from openproblems.datasets.callbacks.callback import Callback
+from openproblems.datasets.callbacks._utils import MimeType
+from openproblems.datasets.callbacks.registry import CallBackRegistry, FILE_REG, BUFF_REG
+from openproblems.datasets.exceptions import CallbackError
+import joblib as jl
+
+URL_t = Union[str, URL, PathLike]
+
+
+class BaseLoader(ABC):
+    _REGISTRY: CallBackRegistry = None
+    _EVENT_MANAGER = None
+    _FALLBACK_EXCEPTIONS = ()
+
+    def __init__(self,
+                 cb_resolution_policy: CallbackResolutionPolicy = CallbackResolutionPolicy.PREFER_SUPPLIED,
+                 cb_error_policy: CallbackErrorPolicy = CallbackErrorPolicy.TRY_REST):
+        self._cb_resolution_policy = cb_resolution_policy
+        self._cb_error_policy = cb_error_policy
+
+    @singledispatchmethod
+    def download(self, url: Union[str, PathLike], **kwargs) -> Any:
+        raise NotImplemented(type(url))
+
+    @download.register(PathLike)
+    @download.register(URL)
+    @download.register(str)
+    def _(self, url: URL_t, **kwargs) -> Any:
+        callback = url.callback if isinstance(url, URL) else None
+        if callback is not None:
+            callback = Callback(callback)
+
+        try:
+            return self._download(url, callback=callback, **kwargs)
+        except self._FALLBACK_EXCEPTIONS:
+            if isinstance(url, URL):
+                return self.download(url.next, **kwargs)
+            raise
+        except CallbackError as e:
+            return self._resolve_callback_error(url, error=e, **kwargs)
+
+    # TODO: maybe be less strict
+    @download.register(frozenset)
+    @download.register(set)
+    @download.register(list)
+    @download.register(tuple)
+    def _(self, url: Sequence[URL_t], **kwargs) -> Any:
+        with jl.Parallel(n_jobs=kwargs.pop("n_jobs", None)) as par:
+            # warning: self.download can cause recursion
+            return tuple(par(jl.delayed(self.download)(u, **kwargs) for u in url))
+
+    def _resolve_callback_error(self, url: URL_t, *, error: CallbackError, **kwargs):
+        if self._cb_error_policy == CallbackErrorPolicy.RAISE:
+            raise error
+
+        if self._cb_error_policy == CallbackErrorPolicy.TRY_REST:
+            failed_cb, *_ = error.args
+            if not isinstance(failed_cb, Callback):
+                raise TypeError(f"Expected the failed callback to be of type `Callback`, "
+                                f"found `{type(failed_cb).__name__}`.") from error
+
+            for callback in self._REGISTRY.sort_closest_to(failed_cb):
+                try:
+                    # TODO
+                    return self._download(url, callback=callback, **kwargs)
+                except CallbackError:
+                    pass
+                except self._FALLBACK_EXCEPTIONS:
+                    raise error from None  # most likely not recoverable
+                except Exception:
+                    pass
+
+            raise error
+
+        raise NotImplementedError(self._cb_error_policy)
+
+    def _resolve_callback_preference(self, url: Union[str, PathLike, BufferedIOBase],
+                                     callback: Optional[Callback] = None) -> Callback:
+        try:
+            raise  # check if we're currently handling a CallbackError
+        except CallbackError:
+            assert callback is not None, "Resolution callback is not set."
+            return callback  # if so, override any preference since it doesn't matter
+        except RuntimeError:
+            pass  # not handling an any exception
+
+        mime_type = MimeType.get(url)
+
+        if callback is None:
+            return self._REGISTRY[mime_type]
+
+        if mime_type in self._REGISTRY:
+            if self._cb_resolution_policy == CallbackResolutionPolicy.PREFER_SUPPLIED:
+                return callback
+            if self._cb_resolution_policy == CallbackResolutionPolicy.PREFER_INFERRED:
+                return self._REGISTRY[mime_type]
+
+        raise NotImplementedError(self._cb_resolution_policy)
+
+    @abstractmethod
+    def _download(self, url: URL_t, callback: Optional[Callback] = None, **kwargs) -> Any:
+        pass
+
+
+class LocalfileDownloader(BaseLoader):
+    _REGISTRY = FILE_REG
+    _FALLBACK_EXCEPTIONS = OSError
+
+    def _download(self, url: URL_t, callback: Optional[Callback] = None, **kwargs) -> Any:
+        return self._resolve_callback_preference(url, callback=callback)(url, **kwargs)
+
+
+class RemoteURLDownloader(BaseLoader):
+    _REGISTRY = BUFF_REG
+    _FALLBACK_EXCEPTIONS = HTTPError
+
+    def __init__(self, retries: int = 3, timeout: int = 600, chunk_size: int = 8192):
+        # TODO: expose policies?
+        super().__init__()
+        self._session = Session()
+        self._retries = retries
+        self._timeout = timeout
+        self._chunk_size = chunk_size
+
+        if self._retries > 0:
+            adapter = HTTPAdapter(
+                max_retries=Retry(
+                    total=self._retries,
+                    redirect=5,
+                    allowed_methods=["HEAD", "GET", "OPTIONS"],
+                    status_forcelist=[413, 429, 500, 502, 503, 504],
+                    backoff_factor=1,
+                )
+            )
+            self._session.mount("ftp://", adapter)
+            self._session.mount("http://", adapter)
+            self._session.mount("https://", adapter)
+
+    def _download(self, url: Union[str, PathLike], callback: Optional[Callback] = None,
+                  params: Optional[Mapping[str, str]] = None, **kwargs) -> Any:
+        handle = BytesIO()
+        req = self._session.prepare_request(
+            Request(
+                "GET",
+                url,
+                params=params,
+                headers={"User-agent": "openproblems-user"},
+            )
+        )
+
+        with self._session.send(req, stream=True, timeout=self._timeout) as resp:
+            resp.raise_for_status()
+            total = resp.headers.get("content-length", None)
+
+            with tqdm(
+                    unit="B",
+                    unit_scale=True,
+                    miniters=1,
+                    unit_divisor=1024,
+                    total=total if total is None else int(total),
+                    disable=kwargs.pop("disable", False),
+            ) as t:
+                for chunk in resp.iter_content(chunk_size=self._chunk_size):
+                    t.update(len(chunk))
+                    handle.write(chunk)
+
+                handle.flush()
+                handle.seek(0)
+
+        return self._resolve_callback_preference(handle, callback=callback)(handle, ** kwargs)

--- a/openproblems/datasets/loaders/sfaira_loader.py
+++ b/openproblems/datasets/loaders/sfaira_loader.py
@@ -1,0 +1,10 @@
+from typing import Optional, Any
+
+from openproblems.datasets.callbacks.callback import Callback
+from openproblems.datasets.loaders.loader import BaseLoader, URL_t
+
+
+class SFAIRALoader(BaseLoader):
+    def _download(self, url: URL_t, callback: Optional[Callback] = None, **kwargs) -> Any:
+        raise NotImplementedError("SFAIRA loaders are not implemented.")
+

--- a/openproblems/datasets/metadata.py
+++ b/openproblems/datasets/metadata.py
@@ -1,0 +1,26 @@
+from typing import Optional, Union, Sequence
+from datetime import date
+from dataclasses import dataclass, field
+from openproblems.datasets.url import URL
+
+
+@dataclass(frozen=True, order=False)
+class Metadata:
+    name: str
+    author: str
+    year: Union[int, date]  # TODO: warn if int?
+    url: Union[str, URL, Sequence[Union[str, URL]]] = field(repr=False)
+    description: Optional[str] = field(default=None, repr=False)
+
+    def __post_init__(self):
+        url = self.url
+        if not isinstance(self.year, date):
+            object.__setattr__(self, "url", date(year=self.year, month=1, day=1))
+
+        if isinstance(url, str):
+            url = (url,)
+        url = tuple(u if isinstance(u, URL) else URL(u) for u in url)
+        if len(url) == 1:  # no multiple files
+            url = url[0]
+
+        object.__setattr__(self, "url", url)

--- a/openproblems/datasets/url.py
+++ b/openproblems/datasets/url.py
@@ -1,0 +1,31 @@
+from typing import Iterable, Tuple, Union, Optional, Callable
+
+
+class URL(str):
+    def __new__(cls, *args, fallback: Optional[Union[str, Iterable[str]]] = None, callback: Optional[Callable] = None):
+        # TODO: type the callback properly
+        res = super().__new__(cls, *args)
+        if isinstance(fallback, (str, type(None))):
+            fallback = (fallback,)
+        # TODO: disallow URL in fallback?
+        fallback = tuple(f for f in fallback if f != res)
+
+        res._fallback = fallback
+        res._callback = callback
+
+        return res
+
+    @property
+    def callback(self) -> Optional[Callable]:
+        return self._callback
+
+    @property
+    def fallback(self) -> Tuple[str, ...]:
+        return self._fallback
+
+    @property
+    def next(self) -> "URL":
+        if not len(self._fallback):
+            raise RuntimeError("No more callbacks.")  # TODO: custom exc
+
+        return URL(self.fallback[0], fallback=self.fallback[1:], callback=self.callback)

--- a/openproblems/exceptions.py
+++ b/openproblems/exceptions.py
@@ -1,0 +1,3 @@
+# TODO: create EXC hierarchy
+class SCOPException(Exception):
+    pass


### PR DESCRIPTION
This a a first and partially working re-implementation of getting the datasets. I've currrently ported only `Zebrafish` just now, can be tested as:
```python3
import openproblems as op

op.datasets.multimodal.Zebrafish().load()  # this will change to op.datasets.multimodal.Zebrafish.load() or similar
```
What it currently tackles:
- robust exception handling
- caching (NYI - have used [cacheout](https://cacheout.readthedocs.io/en/latest/) which supports cache policies (like least recently/frequently used) and I have somewhere lying implementation with file backend 
- automatic filetype detection using MIME to determine callbacks (they are predifined [here](https://github.com/singlecellopenproblems/SingleCellOpenProblems/compare/master...michalk8:update_datasets?expand=1#diff-c6af410826f35d9c78623d93fa417e694336aa93bd0117200f0627a8826730d4R66)): I hop
- callbacks can also be specified on a per-url basis (even with fallback callbacks and policies which decide what to do when a clash happens - e.g. MIME tells us 1 thing, user other)
- fallback urls when error occurs - for `local` files, it's invoked only on OS erros, for `remove`, on HTTP errors
- more declarative definition of a dataset (see the Zebrafish example below): this could allow to have limited definition outside of Python using `.yml` files (not really a priority)
- implemented common functions like:
  - validators: e.g. certain keys of certain types are present
  - processors: sparsify dense count data, ensure all arrays are floats/doubles/etc., remove empty cells/genes, make unique {cell, gene} names
- samplers: e.g. group balanced with multiple grouping keys (generalization of the current `subsample_even`)
- event based system to register custom callbacks for diff. event (like 
- exception hierarchy (still WIP)
- doesn't download the file onto disk and then into memory (can be slow), but directly into memory
- multiple sources are downloaded in parallel so that we're IO bound
- everything is in the sample place (dataset definition + metadata annotation), nicer project tree structure
- group metadata into 1 class

```python
class Zebrafish(Dataset):
    METADATA = Metadata(
        name="Zebrafish",
        author="Foo",
        year=2016,
        url="https://ndownloader.figshare.com/files/24566651?private_link=e3921450ec1bd0587870"
    )
   # this is optional (but the defaults are not great)
    _SAMPLER = (
        GroupBalancedSampler(keys="lab", sampler=SizedSampler(500, cells=True)) >>
        RemoveEmpty() >>  
        SizedSampler(100, cells=False) >>
        RemoveEmpty()
    )
```
Currently, the process is:
- 1.0 try fetching the data from cache, if not present, load the data (possible from multiple files) from local/remote resource (depends on the `Loader` type)
- 1.1. if multiple files, start download in parallel
- 1.2 if a HTTPError is throws and no backup URL is present, raise
- 1.3 otherwise try the backup url, etc.
- 1.4 if a callback error is present, depending on the policy, either raise the error or try the different callbacks
- 1.5 if any other callback succeeds (i.e. doesn't raise an error), return the value, otherwise raise the original error
- 2.0. if multiple files were downloaded, combine them object
- 3.0. post-process the data (add/remove cols in obs/var, set dtypes to e.g. categorical, sparsify the data, ...)
- 4.0 verify that the object is correct (e.g. it's really an AnnData object, it some keys, ...)

Each of these steps is handled by the `EventManager` (one per dataset) and it's flexible enough for others to register their functions. The base `Dataset` class has no-op processor, just checks whether it's an `AnnData` and has a fixed-size sampler (selects the first `N` cells and genes).
When deriving from a new class, when defining e.g. `_SAMPLER` as below, it's completely overriden. An alternative would be to just add the new functions to the registry with a higher priority, but in general, I think this would more often break things than not (I've added the possibility in `__initialize__` class method [here](https://github.com/singlecellopenproblems/SingleCellOpenProblems/compare/master...michalk8:update_datasets?expand=1#diff-37515d6f98c05a9bdf617f31122411615ce5fa7ccc6334cdaf02f54e71befc40R38) - that's where I intend to inject cache handlers).

Problems:
- mutimodal dataset were giving me a lot of trouble (this is the 2nd iteration I have), still not sure if they can be handled gracefully with this approach
- class hierarchy still feels clunky (either completely override or use the "low-level" `__initialize__` to register the callbacks and put them into the proper places)
- maybe dataset definition is a bit too complex (e.g. knowing the processor/validator/sampler classes)*

*I envision that in the end, you can just type normal function, as long as their signature is correct (I'm almost [there](https://github.com/singlecellopenproblems/SingleCellOpenProblems/compare/master...michalk8:update_datasets?expand=1#diff-6f819de01eef4d840f9b13c919225995b311ae49aa662ee8f8441a13733e0bfeR20))
```python3
class FooDataset(Dataset):
     # is transformed using: Validator.from_callback(fn_1) >>Validator.from_callback(fn_2) >> ...
    _VALIDATORS = [lambda a: is_categorical_dtype(a.obs['foo']), lambda a: ...]
```

Meta TODOs:
- [ ] feedback from @LuckyMD and @scottgigante regarding the API
- [ ] handle TODOs in the code
- [ ] fix bugs

TODOs after Meta TODOs:
- [ ] sfaira?
- [ ] tests
- [ ] logging
- [ ] documentation
- [ ] cleaning the code (black/isort/mypy)

closes #125 
potentially closes #131 #132