### PR TITLE
New key breaks r docker container build

### DIFF
--- a/docker/openproblems-r-base/Dockerfile
+++ b/docker/openproblems-r-base/Dockerfile
@@ -19,9 +19,7 @@ WORKDIR /
 # Install R
 RUN apt-get update -qq
 RUN apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install dirmngr ca-certificates gnupg gpgv gfortran libblas-dev liblapack-dev
-RUN gpg --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
-RUN gpg --output key.gpg --export 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
-RUN apt-key add key.gpg
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
 RUN echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >> /etc/apt/sources.list
 RUN apt-get update -qq
 RUN apt-get install -yq --no-install-suggests --no-install-recommends r-base-dev=4.0\*

--- a/docker/openproblems-r-base/Dockerfile
+++ b/docker/openproblems-r-base/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenti
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
 RUN echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >> /etc/apt/sources.list
 RUN apt-get update -qq
-RUN apt-get install -yq --no-install-suggests --no-install-recommends r-base-dev=4.0\*
+RUN apt-get install -yq --no-install-suggests --no-install-recommends r-base-dev=4.1\*
 RUN apt-get clean -y && apt-get autoremove -y
 
 # Install R packages


### PR DESCRIPTION
A new key for the R repo (see https://cloud.r-project.org/) breaks building the R container.
This PR fixes that.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Submission type

* [ ] This submission adds a new dataset
* [ ] This submission adds a new method
* [ ] This submission adds a new metric
* [ ] This submission adds a new task
* [ ] This submission adds a new Docker image
* [x] This submission fixes a bug (link to related issue: )
* [ ] This submission adds a new feature not listed above