### PR TITLE
Scottgigante/feature/layers counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ If you are unable to write your method using our base dependencies, you may add 
 
 Datasets are loaded under `openproblems/data`. Each data loading function should download the appropriate dataset from a stable location (e.g. from Figshare) be decorated with `openproblems.data.utils.loader` in order to cache the result.
 
-Data should not be normalized. We assume that `adata.X` contains the raw (count) data for the primary modality; this will also be copied to `adata.layers["counts"]` for permanent access to the raw data. Additional modalities should be stored in `adata.obsm`. Prenormalized data (if available) can be stored in `adata.layers`, preferably using a name corresponding to the equivalent [normalization function](./openproblems/tools/normalize.py) (e.g., `adata.layers["log_scran_pooling"]`). 
+Data should be provided in a raw count format. We assume that `adata.X` contains the raw (count) data for the primary modality; this will also be copied to `adata.layers["counts"]` for permanent access to the raw data. Additional modalities should be stored in `adata.obsm`. Prenormalized data (if available) can be stored in `adata.layers`, preferably using a name corresponding to the equivalent [normalization function](./openproblems/tools/normalize.py) (e.g., `adata.layers["log_scran_pooling"]`). 
 
 To see a gold standard loader, look at [openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py](./openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py)
 
@@ -197,7 +197,7 @@ For datasets in particular, these should be loaded using a `loader` function fro
 
 For methods and metrics, they should be decorated with the appropriate function in `openproblems.tools.decorators` to include metadata required for the evaluation and presentation of results.
 
-Note that data is not normalized in the data loader; normalization should be performed as part of each method. For ease of use, we provide a collection of common normalization functions in [`openproblems.tools.normalize`](openproblems/tools/normalize.py). The original data stored in `adata.X` is automatically stored in `adata.layers["counts"]` for later reference in the case the a metric needs to access the unnormalized data.
+Note that data is not normalized in the data loader; normalization should be performed as part of each method or in the task dataset function if stated in the task API. For ease of use, we provide a collection of common normalization functions in [`openproblems.tools.normalize`](openproblems/tools/normalize.py). The original data stored in `adata.X` is automatically stored in `adata.layers["counts"]` for later reference in the case the a metric needs to access the unnormalized data.
 
 ### Adding a new task
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,9 +179,9 @@ If you are unable to write your method using our base dependencies, you may add 
 
 Datasets are loaded under `openproblems/data`. Each data loading function should download the appropriate dataset from a stable location (e.g. from Figshare) be decorated with `openproblems.data.utils.loader` in order to cache the result.
 
-Data should not be normalized. We assume that `adata.X` contains the raw (count) data for the primary modality; additional modalities should be stored in `adata.obsm`.
+Data should not be normalized. We assume that `adata.X` contains the raw (count) data for the primary modality; this will also be copied to `adata.layers["counts"]` for permanent access to the raw data. Additional modalities should be stored in `adata.obsm`. Prenormalized data (if available) can be stored in `adata.layers`, preferably using a name corresponding to the equivalent [normalization function](./openproblems/tools/normalize.py) (e.g., `adata.layers["log_scran_pooling"]`). 
 
-To see a gold standard loader, look at [openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py](https://github.com/singlecellopenproblems/SingleCellOpenProblems/blob/master/openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py)
+To see a gold standard loader, look at [openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py](./openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py)
 
 This file name should match `[First Author Last Name]_[Year Published]_short_Description_of_data.py`. E.g. the dataset of zebrafish embryos perturbed with CRISPR published in 2018 by Wagner _et al._ becomes `Wagner_2018_zebrafish_embryo_CRISPR.py`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,8 @@ If you are unable to write your method using our base dependencies, you may add 
 
 Datasets are loaded under `openproblems/data`. Each data loading function should download the appropriate dataset from a stable location (e.g. from Figshare) be decorated with `openproblems.data.utils.loader` in order to cache the result.
 
+Data should not be normalized. We assume that `adata.X` contains the raw (count) data for the primary modality; additional modalities should be stored in `adata.obsm`.
+
 To see a gold standard loader, look at [openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py](https://github.com/singlecellopenproblems/SingleCellOpenProblems/blob/master/openproblems/data/Wagner_2018_zebrafish_embryo_CRISPR.py)
 
 This file name should match `[First Author Last Name]_[Year Published]_short_Description_of_data.py`. E.g. the dataset of zebrafish embryos perturbed with CRISPR published in 2018 by Wagner _et al._ becomes `Wagner_2018_zebrafish_embryo_CRISPR.py`
@@ -195,7 +197,7 @@ For datasets in particular, these should be loaded using a `loader` function fro
 
 For methods and metrics, they should be decorated with the appropriate function in `openproblems.tools.decorators` to include metadata required for the evaluation and presentation of results.
 
-Note that data is not normalized in the data loader; normalization should be performed as part of each method. For ease of use, we provide a collection of common normalization functions in [`openproblems.tools.normalize`](openproblems/tools/normalize.py).
+Note that data is not normalized in the data loader; normalization should be performed as part of each method. For ease of use, we provide a collection of common normalization functions in [`openproblems.tools.normalize`](openproblems/tools/normalize.py). The original data stored in `adata.X` is automatically stored in `adata.layers["counts"]` for later reference in the case the a metric needs to access the unnormalized data.
 
 ### Adding a new task
 

--- a/openproblems/data/utils.py
+++ b/openproblems/data/utils.py
@@ -48,7 +48,8 @@ def loader(func, *args, **kwargs):
         log.debug("Downloading {}({}, {}) dataset".format(func.__name__, args, kwargs))
         adata = func(*args, **kwargs)
         adata.__from_cache__ = False
-        adata.layers["counts"] = adata.X
+        if "counts" not in adata.layers:
+            adata.layers["counts"] = adata.X
         try:
             os.mkdir(TEMPDIR)
         except OSError:

--- a/openproblems/data/utils.py
+++ b/openproblems/data/utils.py
@@ -48,6 +48,7 @@ def loader(func, *args, **kwargs):
         log.debug("Downloading {}({}, {}) dataset".format(func.__name__, args, kwargs))
         adata = func(*args, **kwargs)
         adata.__from_cache__ = False
+        adata.layers["counts"] = adata.X
         try:
             os.mkdir(TEMPDIR)
         except OSError:

--- a/test/test__load_data.py
+++ b/test/test__load_data.py
@@ -33,6 +33,7 @@ def test_load_dataset(task_name, dataset_name, test, tempdir, image):
     dataset = getattr(task.datasets, dataset_name)
     adata = dataset(test=test)
     utils.asserts.assert_finite(adata.X)
+    utils.asserts.assert_array_equal(adata.X, adata.layers["counts"])
     adata2 = dataset(test=test)
     assert adata2.shape == adata.shape
     assert adata2.__from_cache__


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

In order to ensure metrics have access to the raw counts, I'm saving `adata.X` in `adata.layers["counts"]` within the data loader decorator. This doesn't solve the corresponding problem for multimodal data. 

Two other options to solve this:
* require dataset loaders within a specific task do this manually only for the tasks that require it, but I think it's a general enough application to want to do it generally
* put this functionality inside the normalizer decorator so the raw counts are only stored if/when `adata.X` is modified. This gets tricky if a particular method doesn't use any of the normalizers, a metric would have to check if the raw is available and if not use `.X`. 

### Submission type

* [ ] This submission adds a new dataset
* [ ] This submission adds a new method
* [ ] This submission adds a new metric
* [ ] This submission adds a new task
* [ ] This submission adds a new Docker image
* [ ] This submission fixes a bug (link to related issue: )
* [X] This submission adds a new feature not listed above

### Testing

* [X] This submission was written on a forked copy of SingleCellOpenProblems
* [X] GitHub Actions "Run Benchmark" tests are passing on this base branch of this pull request (include link to passed test: https://github.com/scottgigante-immunai/openproblems/runs/5756619470?check_suite_focus=true)
* [X] If this pull request is not ready for review (including passing the "Run Benchmark" tests), I will open this PR as a draft (click on the down arrow next to the "Create Pull Request" button)

### Submission guidelines

* [X] This submission follows the guidelines in our [Contributing](../blob/master/CONTRIBUTING.md) document
* [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change

### PR review checklist

This PR will be evaluated on the basis of the following checks:

* [ ] The task addresses a valid open problem in single-cell analysis
* [X] The latest version of master is merged and tested
* [ ] The methods/metrics are imported to `__init__.py` and were tested in the pipeline
* [ ] Method and metric decorators are annotated with paper title, year, author, code version, and date
* [ ] The README gives an outline of the methods, metrics and datasets in the folder
* [ ] The README provides a satisfactory task explanation (for new tasks)
* [ ] The sample test data is appropriate to test implementation of all methods and metrics (for new tasks)
