### PR TITLE
Use branch of scprep to provide R traceback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ install_requires = [
     "numpy>=1.17.0",
     "scikit-learn>=0.19.1",
     "anndata>=0.7.5,<0.8",
-    "scprep>=1.0.10",
+    "scprep @ git+https://github.com/scottgigante-immunai/"
+    "scprep@scottgigante/rfunction/traceback",
     "scipy",
     "scanpy>=1.6",
     "louvain>=0.7",


### PR DESCRIPTION
This is a temporary fix until I get access to the main repo of scprep to merge this feature.

Multiple PRs have been held up by poor error tracing in R -- this fix includes a printed traceback in all `RFunction` errors, which should greatly improve error readability.

Benchmark passed: https://github.com/scottgigante-immunai/openproblems/runs/6242627739?check_suite_focus=true