### PR TITLE
exclude pip 22.1

### DIFF
--- a/docker/openproblems/Dockerfile
+++ b/docker/openproblems/Dockerfile
@@ -20,7 +20,7 @@ RUN \
    find /var/lib/apt/lists/ ! -type d -exec rm '{}' \;
 
 # update pip
-RUN python3 -m pip install --no-cache-dir -U pip
+RUN python3 -m pip install --no-cache-dir -U pip!=22.1.*
 
 # install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/docker/openproblems/Dockerfile
+++ b/docker/openproblems/Dockerfile
@@ -20,7 +20,7 @@ RUN \
    find /var/lib/apt/lists/ ! -type d -exec rm '{}' \;
 
 # update pip
-RUN python3 -m pip install --no-cache-dir -U pip!=22.1.*
+RUN python3 -m pip install --no-cache-dir -U pip setuptools!=0.63.*
 
 # install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
Avoids https://github.com/pypa/pip/issues/11155 which should be fixed by https://github.com/pypa/pip/pull/11136
