### PR TITLE
remove maxfail; print durations

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -208,7 +208,7 @@ jobs:
         cd ..
 
     - name: Run tests
-      run: pytest --cov=openproblems --cov-report=xml -vv --maxfail=2
+      run: pytest --cov=openproblems --cov-report=xml -vv --durations=10
 
     - name: Upload coverage
       continue-on-error: ${{ github.repository != 'openproblems-bio/openproblems' }}

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
     name_func=utils.name.name_test,
     skip_on_empty=True,
 )
-@utils.docker.docker_test(timeout=600, retries=2)
+@utils.docker.docker_test(timeout=60, retries=2)
 def test_method(task_name, method_name, image):
     """Test application of a method."""
     import anndata

--- a/test/utils/docker.py
+++ b/test/utils/docker.py
@@ -223,6 +223,21 @@ def run_image(image, script, *args, timeout=None, retries=0):
         try:
             return run.run(command)
         except Exception as e:
+            if isinstance(e, FileNotFoundError) and "timeout" in str(e):
+                raise FileNotFoundError(
+                    "\n".join(
+                        [
+                            "timeout is not available. Install with",
+                            "```",
+                            "sudo cat <<EOF | sudo tee /usr/local/bin/timeout",
+                            "#!/usr/bin/env bash",
+                            "perl -e 'alarm shift; exec @ARGV' \"$@\"",
+                            "EOF",
+                            "sudo chmod +x /usr/local/bin/timeout",
+                            "```",
+                        ]
+                    )
+                ) from e
             if retries > 0:
                 warnings.warn(
                     'Container failed with {}("{}").'.format(type(e).__name__, str(e)),


### PR DESCRIPTION
maxfail was added by accident. Printing durations will help use triage which tests need to be shortened.