### PR TITLE
replace __from_cache__ with .uns['_from_cache']

### DIFF
--- a/openproblems/data/utils.py
+++ b/openproblems/data/utils.py
@@ -42,12 +42,12 @@ def loader(func, *args, **kwargs):
             "Loading cached {}({}, {}) dataset".format(func.__name__, args, kwargs)
         )
         adata = anndata.read_h5ad(filepath)
-        adata.__from_cache__ = True
+        adata.uns["_from_cache"] = True
         return adata
     else:
         log.debug("Downloading {}({}, {}) dataset".format(func.__name__, args, kwargs))
         adata = func(*args, **kwargs)
-        adata.__from_cache__ = False
+        adata.uns["_from_cache"] = False
         if "counts" not in adata.layers:
             adata.layers["counts"] = adata.X
         try:

--- a/openproblems/tasks/_batch_integration/batch_integration_graph/datasets/immune.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/datasets/immune.py
@@ -7,7 +7,6 @@ import scanpy as sc
 @dataset(dataset_name="Immune (by batch)", image="openproblems")
 def immune_batch(test=False):
     adata = load_immune(test)
-    from_cache = adata.__from_cache__
     adata.obs["labels"] = adata.obs["final_annotation"]
 
     sc.pp.filter_genes(adata, min_counts=1)
@@ -21,6 +20,4 @@ def immune_batch(test=False):
     adata.obsm["X_uni"] = adata.obsm["X_pca"]
 
     sc.pp.neighbors(adata, use_rep="X_uni", key_added="uni")
-
-    adata.__from_cache__ = from_cache
     return adata

--- a/openproblems/tasks/_batch_integration/batch_integration_graph/datasets/pancreas.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/datasets/pancreas.py
@@ -7,7 +7,6 @@ import scanpy as sc
 @dataset(dataset_name="Pancreas (by batch)", image="openproblems")
 def pancreas_batch(test=False):
     adata = load_pancreas(test)
-    from_cache = adata.__from_cache__
     adata.obs["labels"] = adata.obs["celltype"]
     adata.obs["batch"] = adata.obs["tech"]
 
@@ -23,5 +22,4 @@ def pancreas_batch(test=False):
 
     sc.pp.neighbors(adata, use_rep="X_uni", key_added="uni")
 
-    adata.__from_cache__ = from_cache
     return adata

--- a/test/test__load_data.py
+++ b/test/test__load_data.py
@@ -41,5 +41,5 @@ def test_load_dataset(task_name, dataset_name, test, tempdir, image):
     utils.asserts.assert_array_equal(adata.X, adata.layers["counts"])
     adata2 = dataset(test=test)
     assert adata2.shape == adata.shape
-    assert adata2.__from_cache__
+    assert adata2.uns["_from_cache"]
     utils.cache.save(adata, tempdir, task, dataset, test=test)


### PR DESCRIPTION
`adata.__from_cache__` doesn't get included in merges or copies, which caused many problems. Using `uns` should fix this.