### PR TITLE
remove redundant timeout infra

### DIFF
--- a/test/utils/docker.py
+++ b/test/utils/docker.py
@@ -1,3 +1,4 @@
+from . import exceptions
 from . import git
 from . import run
 
@@ -217,28 +218,11 @@ def run_image(image, script, *args, timeout=None, retries=0):
     else:
         container_command = singularity_command
     command = container_command(image, script, *args)
-    if timeout is not None:
-        command = ["timeout", str(timeout)] + command
     while True:
         try:
-            return run.run(command)
+            return run.run(command, timeout=timeout)
         except Exception as e:
-            if isinstance(e, FileNotFoundError) and "timeout" in str(e):
-                raise FileNotFoundError(
-                    "\n".join(
-                        [
-                            "timeout is not available. Install with",
-                            "```",
-                            "sudo cat <<EOF | sudo tee /usr/local/bin/timeout",
-                            "#!/usr/bin/env bash",
-                            "perl -e 'alarm shift; exec @ARGV' \"$@\"",
-                            "EOF",
-                            "sudo chmod +x /usr/local/bin/timeout",
-                            "```",
-                        ]
-                    )
-                ) from e
-            if retries > 0:
+            if retries > 0 and not isinstance(e, exceptions.TimeoutError):
                 warnings.warn(
                     'Container failed with {}("{}").'.format(type(e).__name__, str(e)),
                     RuntimeWarning,

--- a/test/utils/exceptions.py
+++ b/test/utils/exceptions.py
@@ -1,0 +1,2 @@
+class TimeoutError(RuntimeError):
+    pass

--- a/test/utils/run.py
+++ b/test/utils/run.py
@@ -1,3 +1,4 @@
+from . import exceptions
 from . import streams
 
 import logging
@@ -86,7 +87,7 @@ def run(
             time.sleep(1)
             runtime += 1
         if runtime > timeout:
-            raise RuntimeError(
+            raise exceptions.TimeoutError(
                 format_error_timeout(
                     p, timeout, p.stderr if stderr is subprocess.PIPE else p.stdout
                 )


### PR DESCRIPTION
We had two concurrent timeout mechanisms, one with `subprocess.poll` and one with `timeout`. Since `timeout` does not give a helpful error message, I am removing it in favour of the pure python solution.