### PR TITLE
Pin python to 3.8.12

### DIFF
--- a/docker/openproblems/Dockerfile
+++ b/docker/openproblems/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8.12-bullseye
 
 # Adding this comment as a temporary bugfix on 3/30
 


### PR DESCRIPTION
Right at the moment when I pinned all of our packages, a python update broke everything 🤦 . This fixes that.