### PR TITLE
Add CLI test for method optimization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,12 @@ Datasets, methods, and metrics should all be decorated with the appropriate func
 
 Note that data is not normalized in the data loader; normalization should be performed as part of each method or in the task dataset function if stated in the task API. For ease of use, we provide a collection of common normalization functions in [`openproblems.tools.normalize`](openproblems/tools/normalize.py). The original data stored in `adata.X` is automatically stored in `adata.layers["counts"]` for later reference in the case the a metric needs to access the unnormalized data.
 
+To test the performance of a dataset, method, or metric, you can use the command-line interface:
+
+```shell
+openproblems-cli test --help
+```
+
 ### Adding a new task
 
 The task directory structure is as follows

--- a/openproblems/api/README.md
+++ b/openproblems/api/README.md
@@ -18,6 +18,7 @@ positional arguments:
     load                Load a dataset for a task
     run                 Run a method on a dataset
     evaluate            Evaluate a metric on a method
+    test                Test a dataset, method and/or metric
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/openproblems/api/main.py
+++ b/openproblems/api/main.py
@@ -8,11 +8,12 @@ from . import load
 from . import parser
 from . import run
 from . import tasks
+from . import test
 from . import utils
 
 SUBCOMMANDS = {
     utils.module_to_str(module): module
-    for module in [tasks, list, image, load, run, evaluate, hash]
+    for module in [tasks, list, image, load, run, evaluate, hash, test]
 }
 
 

--- a/openproblems/api/parser.py
+++ b/openproblems/api/parser.py
@@ -66,6 +66,11 @@ def parse_output(parser):
     )
 
 
+def parse_test(parser):
+    """Parse the test flag argument"""
+    parser.add_argument("--test", action="store_true", help="Run in test mode")
+
+
 def create_tasks_parser(subparsers):
     """Create the argument parser for ``openproblems-cli tasks``."""
     subparsers.add_parser("tasks", help="List tasks")
@@ -125,9 +130,7 @@ def create_load_parser(subparsers):
         help="Select datasets from a specific task",
         required=True,
     )
-    parser.add_argument(
-        "--test", action="store_true", help="Load the test version of the dataset"
-    )
+    parse_test(parser)
     parse_output(parser)
     parser.add_argument("name", type=str, help="Name of the selected dataset")
 
@@ -145,9 +148,7 @@ def create_run_parser(subparsers):
     parse_input(parser)
     parse_output(parser)
     parser.add_argument("name", type=str, help="Name of the selected method")
-    parser.add_argument(
-        "--test", action="store_true", help="Run the test version of the method"
-    )
+    parse_test(parser)
 
 
 def create_evaluate_parser(subparsers):
@@ -162,6 +163,37 @@ def create_evaluate_parser(subparsers):
     )
     parse_input(parser)
     parser.add_argument("name", type=str, help="Name of the selected metric")
+
+
+def create_test_parser(subparsers):
+    """Create the argument parser for ``openproblems-cli test``."""
+    parser = subparsers.add_parser("test", help="Test a dataset, method and/or metric")
+    parser.add_argument(
+        "--task",
+        "-t",
+        type=str,
+        help="Name of task to test",
+        required=True,
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        help="Name of the dataset to test. If missing, uses the sample dataset",
+        default=None,
+    )
+    parser.add_argument(
+        "--method",
+        type=str,
+        help="Name of the method to test. If missing, uses the sample method",
+        default=None,
+    )
+    parser.add_argument(
+        "--metric",
+        type=str,
+        help="Name of the metric to test. If missing, no metric is run",
+        default=None,
+    )
+    parse_test(parser)
 
 
 def create_parser():
@@ -197,6 +229,7 @@ def create_parser():
         create_run_parser,
         create_evaluate_parser,
         create_hash_parser,
+        create_test_parser,
     ]:
         create_subparser(subparsers)
 

--- a/openproblems/api/test.py
+++ b/openproblems/api/test.py
@@ -1,0 +1,23 @@
+from . import evaluate
+from . import load
+from . import run
+from . import utils
+
+
+def _get_api_function(task_name, method_name):
+    return utils.get_function(task_name, "api", method_name)
+
+
+def main(args):
+    if args.dataset is not None:
+        adata = load.load_dataset(args.task, args.dataset, args.test)
+    else:
+        adata = _get_api_function(args.task, "sample_dataset")()
+    assert _get_api_function(args.task, "check_dataset")(adata)
+    if args.method is not None:
+        adata = run.run_method(adata, args.task, args.method, args.test)
+    else:
+        adata = _get_api_function(args.task, "sample_method")(adata)
+    assert _get_api_function(args.task, "check_method")(adata)
+    if args.metric is not None:
+        return evaluate.evaluate_metric(adata, args.task, args.metric)

--- a/openproblems/api/utils.py
+++ b/openproblems/api/utils.py
@@ -40,7 +40,7 @@ def get_function(task_name, function_type, function_name):
     """Get a function from a task."""
     # check function type
     function_type = function_type.lower()
-    assert function_type in ["datasets", "methods", "metrics"]
+    assert function_type in ["datasets", "methods", "metrics", "api"]
 
     # get function
     task = str_to_task(task_name)

--- a/openproblems/data/utils.py
+++ b/openproblems/data/utils.py
@@ -60,6 +60,7 @@ def loader(data_url):
                     "Downloading {}({}, {}) dataset".format(func.__name__, args, kwargs)
                 )
                 adata = func(*args, **kwargs)
+                adata.strings_to_categoricals()
                 adata.uns["_from_cache"] = False
                 if "counts" not in adata.layers:
                     adata.layers["counts"] = adata.X

--- a/openproblems/tasks/_batch_integration/batch_integration_graph/api.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/api.py
@@ -1,4 +1,5 @@
 from ....data.sample import load_sample_data
+from ....tools.decorators import dataset
 
 import numpy as np
 import scanpy as sc
@@ -22,6 +23,7 @@ def check_method(adata):
     return True
 
 
+@dataset()
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()

--- a/openproblems/tasks/_batch_integration/batch_integration_graph/methods/_utils.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/methods/_utils.py
@@ -19,7 +19,6 @@ def hvg_batch(adata, batch_key, target_genes, adataOut):
 def scale_batch(adata, batch_key):
     from scib.preprocessing import scale_batch
 
-    adata.strings_to_categoricals()
     var = adata.var.copy()
     adata = scale_batch(adata, batch_key)
     adata.var = var

--- a/openproblems/tasks/_batch_integration/batch_integration_graph/methods/mnn.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/methods/mnn.py
@@ -18,7 +18,6 @@ def _mnn(adata):
     from scib.integration import runMNN
     from scib.preprocessing import reduce_data
 
-    adata.strings_to_categoricals()
     adata = runMNN(adata, "batch")
     reduce_data(adata, umap=False)
     adata.uns["method_code_version"] = check_version("mnnpy")

--- a/openproblems/tasks/_batch_integration/batch_integration_graph/methods/scanorama.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/methods/scanorama.py
@@ -18,7 +18,6 @@ def _scanorama(adata, use_rep):
     from scib.integration import runScanorama
     from scib.preprocessing import reduce_data
 
-    adata.strings_to_categoricals()
     adata = runScanorama(adata, "batch")
     reduce_data(adata, umap=False, use_rep=use_rep)
     adata.uns["method_code_version"] = check_version("scanorama")

--- a/openproblems/tasks/denoising/api.py
+++ b/openproblems/tasks/denoising/api.py
@@ -1,4 +1,5 @@
 from ...data.sample import load_sample_data
+from ...tools.decorators import dataset
 
 import numpy as np
 import scipy.sparse
@@ -25,6 +26,7 @@ def check_method(adata):
     return True
 
 
+@dataset()
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()

--- a/openproblems/tasks/dimensionality_reduction/api.py
+++ b/openproblems/tasks/dimensionality_reduction/api.py
@@ -1,4 +1,5 @@
 from ...data.sample import load_sample_data
+from ...tools.decorators import dataset
 
 import numpy as np
 import scanpy as sc
@@ -17,6 +18,7 @@ def check_method(adata):
     return True
 
 
+@dataset()
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     return load_sample_data()

--- a/openproblems/tasks/label_projection/api.py
+++ b/openproblems/tasks/label_projection/api.py
@@ -1,6 +1,7 @@
 from ...data.sample import load_sample_data
 
 import numpy as np
+import pandas as pd
 
 
 def check_dataset(adata):
@@ -8,6 +9,9 @@ def check_dataset(adata):
     assert "labels" in adata.obs
     assert "batch" in adata.obs
     assert "is_train" in adata.obs
+    assert np.issubdtype(adata.obs["is_train"].dtype, bool)
+    assert pd.api.types.is_categorical(adata.obs["batch"])
+    assert pd.api.types.is_categorical(adata.obs["labels"])
     assert np.sum(adata.obs["is_train"]) > 0
     assert np.sum(~adata.obs["is_train"]) > 0
     return True
@@ -34,6 +38,8 @@ def sample_method(adata):
     """Create sample method output for testing metrics in this task."""
     adata.obs["labels_pred"] = adata.obs["labels"]
     adata.obs["labels_pred"][::5] = np.random.choice(
-        5, len(adata.obs["labels_pred"][::5]), replace=True
-    ).astype(str)
+        adata.obs["labels"].cat.categories,
+        len(adata.obs["labels_pred"][::5]),
+        replace=True,
+    )
     return adata

--- a/openproblems/tasks/label_projection/api.py
+++ b/openproblems/tasks/label_projection/api.py
@@ -1,4 +1,5 @@
 from ...data.sample import load_sample_data
+from ...tools.decorators import dataset
 
 import numpy as np
 import pandas as pd
@@ -23,6 +24,7 @@ def check_method(adata):
     return True
 
 
+@dataset()
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()

--- a/openproblems/tasks/multimodal_data_integration/api.py
+++ b/openproblems/tasks/multimodal_data_integration/api.py
@@ -1,4 +1,5 @@
 from ...data.multimodal.sample import load_sample_data
+from ...tools.decorators import dataset
 
 import numpy as np
 
@@ -25,6 +26,7 @@ def check_method(adata):
     return True
 
 
+@dataset()
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     return load_sample_data()

--- a/openproblems/tasks/regulatory_effect_prediction/api.py
+++ b/openproblems/tasks/regulatory_effect_prediction/api.py
@@ -1,4 +1,5 @@
 from ...data.multimodal.sample import load_sample_data
+from ...tools.decorators import dataset
 
 import numpy as np
 
@@ -32,6 +33,7 @@ def check_method(adata):
     return True
 
 
+@dataset()
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()

--- a/openproblems/tools/decorators.py
+++ b/openproblems/tools/decorators.py
@@ -144,7 +144,9 @@ def dataset(dataset_name, data_url, dataset_summary, image="openproblems"):
         @functools.wraps(func)
         def apply_func(*args, **kwargs):
             log.debug("Loading {} dataset".format(func.__name__))
-            return func(*args, **kwargs)
+            adata = func(*args, **kwargs)
+            adata.strings_to_categoricals()
+            return adata
 
         apply_func.metadata = dict(
             dataset_name=dataset_name,

--- a/openproblems/tools/decorators.py
+++ b/openproblems/tools/decorators.py
@@ -125,7 +125,9 @@ def metric(metric_name, maximize, image="openproblems"):
     return decorator
 
 
-def dataset(dataset_name, data_url, dataset_summary, image="openproblems"):
+def dataset(
+    dataset_name=None, data_url=None, dataset_summary=None, image="openproblems"
+):
     """Decorate a dataset function.
 
     Parameters

--- a/test/test_0_tasks.py
+++ b/test/test_0_tasks.py
@@ -48,6 +48,7 @@ class TestTask(unittest.TestCase):
         assert callable(self.task.api.check_method)
         assert callable(self.task.api.sample_dataset)
         assert callable(self.task.api.sample_method)
+        assert hasattr(self.task.api.sample_dataset, "metadata")
 
     def test_task_api_is_consistent(self):
         """Test that a task's API is self-consistent"""

--- a/test/test_3_datasets.py
+++ b/test/test_3_datasets.py
@@ -143,5 +143,6 @@ class TestDataset(unittest.TestCase):
             "dataset_summary",
         ]:
             assert attr in self.dataset.metadata
+            assert self.dataset.metadata[attr] is not None
 
         assert len(self.dataset.metadata["dataset_summary"]) < DATASET_SUMMARY_MAXLEN

--- a/test/test_5_cli.py
+++ b/test/test_5_cli.py
@@ -149,6 +149,37 @@ def test_hash(task, function_type, function_name):
     assert h1 == h2
 
 
+@parameterized.parameterized.expand(
+    [
+        (dataset, method, metric)
+        for dataset in ["zebrafish_labels", None]
+        for method in ["logistic_regression_log_cpm", None]
+        for metric in ["accuracy", None]
+    ],
+    name_func=utils.name.name_test,
+)
+def test_test(dataset, method, metric):
+    """Test pipeline for dev testing."""
+    args = ["test", "--task", "label_projection", "--test"]
+    if dataset is not None:
+        args += ["--dataset", dataset]
+    if method is not None:
+        args += ["--method", method]
+    if metric is not None:
+        args += ["--metric", metric]
+    out = main(
+        args,
+        do_print=False,
+    )
+    if metric is None:
+        assert out is None
+    else:
+        try:
+            float(out)
+        except ValueError:
+            assert False, "result could not be converted to float"
+
+
 def test_zero_metric():
     def __zero_metric(*args):
         return 0.0

--- a/test/test_5_cli.py
+++ b/test/test_5_cli.py
@@ -191,7 +191,7 @@ def test_pipeline():
                 "--test",
                 "--output",
                 dataset_file,
-                "pancreas_batch",
+                "zebrafish_batch",
             ],
             do_print=False,
         )

--- a/test/test_5_cli.py
+++ b/test/test_5_cli.py
@@ -222,7 +222,7 @@ def test_pipeline():
                 "--test",
                 "--output",
                 dataset_file,
-                "zebrafish_batch",
+                "zebrafish_labels",
             ],
             do_print=False,
         )


### PR DESCRIPTION
I realise in writing #468 that there is no straightforward way to test the performance of a new method. This PR adds a function to the CLI, `openproblems-cli test`, which allows straightforward testing of a method's performance with a specific dataset and metric. e.g.
```
openproblems-cli -t label_projection --dataset zebrafish_labels --method logistic_regression_log_cpm --metric accuracy
```
which will allow for simpler hyperparameter optimization by method devs.