### PR TITLE
require tensorflow-cpu

### DIFF
--- a/docker/openproblems-python-tf2.4/requirements.txt
+++ b/docker/openproblems-python-tf2.4/requirements.txt
@@ -1,4 +1,4 @@
 dca==0.3.*
 keras>=2.4,<2.6  # pinned in dca
 pyyaml==5.4.1  # pinned in #431
-tensorflow==2.4.*  # pinned in dca
+tensorflow-cpu==2.4.*  # pinned in dca


### PR DESCRIPTION
DCA uses tensorflow instead of tensorflow-cpu. This fixes that.