### PR TITLE
add xgb to scvi docker image

### DIFF
--- a/docker/openproblems-python-scvi/requirements.txt
+++ b/docker/openproblems-python-scvi/requirements.txt
@@ -2,3 +2,4 @@ jax==0.3.6  # pinned in #313
 jaxlib==0.3.5  # pinned in #313
 scikit-misc==0.1.*
 scvi-tools~=0.16  # pinned in #313
+xgboost==1.6.*


### PR DESCRIPTION
This adds xgboost to the scvi docker image for an scvi+scarches+xgboost label projection method.


### Submission type

* [ ] This submission adds a new dataset
* [ ] This submission adds a new method
* [ ] This submission adds a new metric
* [ ] This submission adds a new task
* [x] This submission adds a new Docker image
* [ ] This submission fixes a bug (link to related issue: )
* [ ] This submission adds a new feature not listed above

### Testing

* [x] This submission was written on a forked copy of SingleCellOpenProblems
* [x] GitHub Actions "Run Benchmark" tests are passing on this base branch of this pull request (include link to passed test: )
* [ ] If this pull request is not ready for review (including passing the "Run Benchmark" tests), I will open this PR as a draft (click on the down arrow next to the "Create Pull Request" button)

### Submission guidelines

* [x] This submission follows the guidelines in our [Contributing](../blob/master/CONTRIBUTING.md) document
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change

### PR review checklist

This PR will be evaluated on the basis of the following checks:

* [ ] The task addresses a valid open problem in single-cell analysis
* [ ] The latest version of master is merged and tested
* [ ] The methods/metrics are imported to `__init__.py` and were tested in the pipeline
* [ ] Method and metric decorators are annotated with paper title, year, author, code version, and date
* [ ] The README gives an outline of the methods, metrics and datasets in the folder
* [ ] The README provides a satisfactory task explanation (for new tasks)
* [ ] The sample test data is appropriate to test implementation of all methods and metrics (for new tasks)
