### PR TITLE
Cache result of `assert_url_accessible`

### DIFF
--- a/openproblems/tasks/denoising/methods/alra.py
+++ b/openproblems/tasks/denoising/methods/alra.py
@@ -12,7 +12,7 @@ log = logging.getLogger("openproblems")
     method_name="ALRA",
     paper_name="Zero-preserving imputation of scRNA-seq data using "
     "low-rank approximation",
-    paper_url="https://www.biorxiv.org/content/10.1101/397588v1",
+    paper_url="https://doi.org/10.1101/397588",
     paper_year=2018,
     code_url="https://github.com/KlugerLab/ALRA",
     image="openproblems-r-extras",

--- a/openproblems/tasks/denoising/methods/no_denoising.py
+++ b/openproblems/tasks/denoising/methods/no_denoising.py
@@ -5,7 +5,7 @@ from ....tools.utils import check_version
 @method(
     method_name="No denoising",
     paper_name="Molecular Cross-Validation for Single-Cell RNA-seq",
-    paper_url="https://www.biorxiv.org/content/10.1101/786269v1",
+    paper_url="https://doi.org/10.1101/786269",
     paper_year=2019,
     code_url="https://github.com/czbiohub/molecular-cross-validation",
 )

--- a/openproblems/tasks/dimensionality_reduction/methods/pca.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/pca.py
@@ -8,7 +8,7 @@ import scanpy as sc
 @method(
     method_name="Principle Component Analysis (PCA) (logCPM, 1kHVG)",
     paper_name="On lines and planes of closest fit to systems of points in space",
-    paper_url="https://www.tandfonline.com/doi/abs/10.1080/14786440109462720",
+    paper_url="https://doi.org/10.1080/14786440109462720",
     paper_year=1901,
     code_url="https://scikit-learn.org/stable/modules/generated/"
     "sklearn.decomposition.PCA.html",

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -16,7 +16,7 @@ _scanvi_method = functools.partial(
 _scanvi_scarches_method = functools.partial(
     method,
     paper_name="Query to reference single-cell integration with transfer learning",
-    paper_url="https://www.biorxiv.org/content/10.1101/2020.07.16.205997v1",
+    paper_url="https://doi.org/10.1101/2020.07.16.205997",
     paper_year=2021,
     code_url="https://github.com/YosefLab/scvi-tools",
     image="openproblems-python-scvi",

--- a/openproblems/tasks/multimodal_data_integration/methods/harmonic_alignment.py
+++ b/openproblems/tasks/multimodal_data_integration/methods/harmonic_alignment.py
@@ -10,7 +10,7 @@ import sklearn.decomposition
 _harmonic_alignment_method = functools.partial(
     method,
     paper_name="Harmonic Alignment",
-    paper_url="https://epubs.siam.org/doi/abs/10.1137/1.9781611976236.36",
+    paper_url="https://doi.org/10.1137/1.9781611976236.36",
     paper_year=2020,
     code_url="https://github.com/KrishnaswamyLab/harmonic-alignment",
 )

--- a/openproblems/tasks/spatial_decomposition/methods/nmfreg.py
+++ b/openproblems/tasks/spatial_decomposition/methods/nmfreg.py
@@ -9,7 +9,7 @@ import numpy as np
     method_name="NMF-reg",
     paper_name="Slide-seq: A scalable technology for measuring genome-wide"
     " expression at high spatial resolution",
-    paper_url="https://science.sciencemag.org/content/363/6434/1463",
+    paper_url="https://doi.org/10.1126/science.aaw1219",
     paper_year=2019,
     code_url="https://github.com/tudaga/NMFreg_tutorial",
 )

--- a/openproblems/tasks/spatial_decomposition/methods/nnls.py
+++ b/openproblems/tasks/spatial_decomposition/methods/nnls.py
@@ -10,7 +10,7 @@ import numpy as np
 @method(
     method_name="Non-Negative Least Squares",
     paper_name="Solving Least Squares Problems",
-    paper_url="https://epubs.siam.org/doi/pdf/10.1137/1.9781611971217.bm",
+    paper_url="https://doi.org/10.1137/1.9781611971217",
     paper_year=1987,
     code_url="https://docs.scipy.org/doc/scipy/"
     "reference/generated/scipy.optimize.nnls.html",

--- a/test/utils/asserts.py
+++ b/test/utils/asserts.py
@@ -1,5 +1,6 @@
 from openproblems.tools.utils import assert_finite  # noqa
 
+import functools
 import numpy as np
 import scipy.sparse
 
@@ -33,6 +34,7 @@ def _response_ok(response):
     return False
 
 
+@functools.lru_cache(None)
 def assert_url_accessible(url):
     import requests
 


### PR DESCRIPTION
Re-polling URLs too many times leads to 403 errors. This should reduce the risk of that by polling each URL at most once.