### PR TITLE
Require minimum celltype count for `spatial_decomposition`

### DIFF
--- a/openproblems/tasks/spatial_decomposition/README.md
+++ b/openproblems/tasks/spatial_decomposition/README.md
@@ -41,10 +41,14 @@ Datasets consists of 2 `anndata.AnnData` objects, concatenated by key
 * `sc` for the single cell reference.
 * `sp` for the target spatial dataset.
 
-In the single cell reference, cell-types are stored in `adata_sc.obs["label"]`.
+In the single cell reference, cell-types are stored in `adata_sc.obs["label"]`. No label
+may have fewer than 25 cells.
+
 In the spatial target, ground-truth cell-type proportions are stored in
 `adata_spatial.obsm["proportions_true"]`.
+
 Methods should return only the spatial data with inferred proportions stored in
 `adata_spatial.obsm["proportions_pred"]`.
+
 Metrics shall compare `adata_spatial.obsm['proportions_pred']` to
 `adata_spatial.obsm['proportions_true']`.

--- a/openproblems/tasks/spatial_decomposition/api.py
+++ b/openproblems/tasks/spatial_decomposition/api.py
@@ -7,6 +7,8 @@ from pandas.core.dtypes.common import is_categorical_dtype
 
 import numpy as np
 
+CELLTYPE_MIN_CELLS = 25
+
 
 def check_dataset(adata: AnnData):
     """Check that dataset output fits expected API."""
@@ -16,13 +18,17 @@ def check_dataset(adata: AnnData):
     # check that proportions are included
     assert "proportions_true" in adata.obsm
     assert isinstance(adata.obsm["proportions_true"], np.ndarray)
-    # make sure proportions sum to one, some precision error allowed
-    proportions_sum = np.sum(
-        adata[adata.obs["modality"] == "sp"].obsm["proportions_true"], axis=1
-    )
-    np.testing.assert_allclose(proportions_sum, 1)
-    # ensure cell type labels are found in single cell reference
+    assert "label" in adata.obs
     assert is_categorical_dtype(adata.obs["label"])
+    assert "modality" in adata.obs
+    assert np.all(np.isin(adata.obs["modality"], ["sc", "sp"]))
+    adata_sc, adata_sp = split_sc_and_sp(adata)
+    # make sure proportions sum to one, some precision error allowed
+    proportions_sum = np.sum(adata_sp.obsm["proportions_true"], axis=1)
+    np.testing.assert_allclose(proportions_sum, 1)
+    # make sure no celltype labels are too rare
+    celltype_counts = adata_sc.obs["label"].value_counts()
+    assert np.all(celltype_counts >= CELLTYPE_MIN_CELLS)
     return True
 
 

--- a/openproblems/tasks/spatial_decomposition/datasets/utils.py
+++ b/openproblems/tasks/spatial_decomposition/datasets/utils.py
@@ -1,3 +1,4 @@
+from ..api import CELLTYPE_MIN_CELLS
 from ..utils import merge_sc_and_sp
 from typing import Sequence
 from typing import Union
@@ -54,6 +55,8 @@ def generate_synthetic_dataset(
 
     The cell type labels are stored in adata_sc.obs["label"].
     """
+    # remove rare celltypes
+    adata = filter_celltypes(adata)
 
     # set random generator seed
     rng = np.random.default_rng(seed)
@@ -138,3 +141,10 @@ def generate_synthetic_dataset(
     adata_merged.layers["counts"] = adata_merged.X.copy()
 
     return adata_merged
+
+
+def filter_celltypes(adata, min_cells=CELLTYPE_MIN_CELLS):
+    """Filter rare celltypes from an AnnData"""
+    celltype_counts = adata.obs["label"].value_counts() >= min_cells
+    keep_cells = np.isin(adata.obs["label"], celltype_counts.index[celltype_counts])
+    return adata[adata.obs.index[keep_cells]].copy()

--- a/openproblems/tasks/spatial_decomposition/methods/rctd.py
+++ b/openproblems/tasks/spatial_decomposition/methods/rctd.py
@@ -3,7 +3,6 @@ from ....tools.decorators import method
 from ....tools.utils import check_r_version
 from ..utils import split_sc_and_sp
 
-import anndata as ad
 import numpy as np
 
 _rctd = r_function("rctd.R", args="sce_sc, sce_sp")
@@ -22,18 +21,6 @@ RCTD_MIN_CELLTYPE_COUNT = 25
 def rctd(adata, test=False):
     # exctract single cell reference data
     adata_sc, adata = split_sc_and_sp(adata)
-
-    # sample to min 25 cells per celltype
-    celltype_counts = adata_sc.obs["label"].value_counts() >= RCTD_MIN_CELLTYPE_COUNT
-    keep_cells = np.isin(adata_sc.obs["label"], celltype_counts.index[celltype_counts])
-    keep_idx = adata_sc.obs.index[keep_cells]
-    for celltype in celltype_counts.index[~celltype_counts]:
-        keep_idx = adata_sc.obs["label"] == celltype
-        sample_idx = np.random.choice(adata_sc.obs.index[keep_idx], 25, replace=True)
-        keep_idx = np.concatenate([keep_idx, sample_idx])
-        
-    adata_sc = adata_sc[keep_idx].copy()
-    adata_sc.obs_names_make_unique()
 
     # set spatial coordinates for the single cell data
     adata_sc.obsm["spatial"] = np.ones((adata_sc.shape[0], 2))

--- a/openproblems/tasks/spatial_decomposition/methods/rctd.py
+++ b/openproblems/tasks/spatial_decomposition/methods/rctd.py
@@ -7,8 +7,6 @@ import numpy as np
 
 _rctd = r_function("rctd.R", args="sce_sc, sce_sp")
 
-RCTD_MIN_CELLTYPE_COUNT = 25
-
 
 @method(
     method_name="RCTD",


### PR DESCRIPTION
RCTD was failing due to some datasets having <25 cells for a given celltype label. Since this is a reasonable requirement, @LuckyMD and I decided we should just enforce it as part of the task API rather than try to fix RCTD to run even in the presence of rare celltypes.

cc @giovp 