### PR TITLE
Pin igraph to 0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     "scipy>=1.8,<1.10",
     "scanpy>=1.6",
     "louvain==0.7.*",
-    "python-igraph==0.10.1",
     "decorator<5.0",  # pinned in #324
     "memory-profiler==0.60",
     "colorama==0.4.*",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     "scipy>=1.8,<1.10",
     "scanpy>=1.6",
     "louvain==0.7.*",
+    "python-igraph==0.10.1",
     "decorator<5.0",  # pinned in #324
     "memory-profiler==0.60",
     "colorama==0.4.*",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "scipy>=1.8,<1.10",
     "scanpy>=1.6",
     "louvain==0.7.*",
-    "python-igraph==0.10.1",
+    "python-igraph<0.10",
     "decorator<5.0",  # pinned in #324
     "memory-profiler==0.60",
     "colorama==0.4.*",


### PR DESCRIPTION
igraph 0.10 (release September 6) is causing errors with louvain, e.g.

```
=================================== FAILURES ===================================
_ test_metric_batch_integration_graph_ari_openproblems_python_batch_integration _
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/parameterized/parameterized.py", line 533, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "<decorator-gen-55>", line 2, in test_metric
  File "/__w/openproblems/openproblems/test/utils/docker.py", line 267, in docker_test
    run_image(image, f, timeout=timeout, retries=retries)
  File "/__w/openproblems/openproblems/test/utils/docker.py", line 223, in run_image
    return run.run(command, timeout=timeout)
  File "/__w/openproblems/openproblems/test/utils/run.py", line 116, in run
    _run_failed(p, error_raises, format_error)
  File "/__w/openproblems/openproblems/test/utils/run.py", line 39, in _run_failed
    raise error_raises(format_error(process))
AssertionError: docker exec 26f6e018abe4 /bin/bash /__w/openproblems/openproblems/test/docker_run.sh /__w/openproblems/openproblems/test/ /tmp/tmpvcb14lln/test_metric.py
Return code 1

/__w/openproblems/openproblems/openproblems/data/sample.py:26: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = anndata.AnnData(rna_data, obs=cells, var=genes)
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.8/site-packages/coverage/__main__.py", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/coverage/cmdline.py", line 943, in main
    status = CoverageScript().command_line(argv)
  File "/usr/local/lib/python3.8/site-packages/coverage/cmdline.py", line 659, in command_line
    return self.do_run(options, args)
  File "/usr/local/lib/python3.8/site-packages/coverage/cmdline.py", line 830, in do_run
    runner.run()
  File "/usr/local/lib/python3.8/site-packages/coverage/execfile.py", line 199, in run
    exec(code, main_mod.__dict__)
  File "/tmp/tmpvcb14lln/test_metric.py", line 20, in <module>
    test_metric(*('batch_integration_graph', 'ari', 'openproblems-python-batch-integration'), **{})
  File "/tmp/tmpvcb14lln/test_metric.py", line 12, in test_metric
    m = metric(adata)
  File "/__w/openproblems/openproblems/openproblems/tools/decorators.py", line 118, in apply_metric
    return func(*args, **kwargs)
  File "/__w/openproblems/openproblems/openproblems/tasks/_batch_integration/batch_integration_graph/metrics/ari.py", line 25, in ari
    opt_louvain(
  File "/usr/local/lib/python3.8/site-packages/scib/metrics/clustering.py", line 82, in opt_louvain
    sc.tl.louvain(adata, resolution=res, key_added=cluster_key)
  File "/usr/local/lib/python3.8/site-packages/scanpy/tools/_louvain.py", line 151, in louvain
    part = louvain.find_partition(
  File "/usr/local/lib/python3.8/site-packages/louvain/functions.py", line 68, in find_partition
    partition = partition_type(graph,
  File "/usr/local/lib/python3.8/site-packages/louvain/VertexPartition.py", line [769](https://github.com/openproblems-bio/openproblems/actions/runs/3040354545/jobs/4897707005#step:12:770), in __init__
    self._partition = _c_louvain._new_RBConfigurationVertexPartition(pygraph_t,
BaseException: Could not construct partition: vector::_M_default_append
Clustering...
```