### PR TITLE
Revert "temporarily remove cell cell comm"

### DIFF
--- a/openproblems/tasks/__init__.py
+++ b/openproblems/tasks/__init__.py
@@ -6,6 +6,5 @@ from . import regulatory_effect_prediction
 from . import spatial_decomposition
 from ._batch_integration import batch_integration_embed
 from ._batch_integration import batch_integration_graph
-
-# from ._cell_cell_communication import cell_cell_communication_ligand_target
-# from ._cell_cell_communication import cell_cell_communication_source_target
+from ._cell_cell_communication import cell_cell_communication_ligand_target
+from ._cell_cell_communication import cell_cell_communication_source_target


### PR DESCRIPTION
This reverts commit 1068e5f4011f2e06fd01cdb4d6055aed16d1a484.

Cell cell communication was causing benchmarks to fail: https://github.com/openproblems-bio/openproblems/actions/runs/3136011677/jobs/5095990766

We need to identify the problem before we can merge it back in.