### PR TITLE
add rlang traceback in seurat methods

### DIFF
--- a/openproblems/tasks/label_projection/methods/seurat.R
+++ b/openproblems/tasks/label_projection/methods/seurat.R
@@ -7,6 +7,8 @@
 #' Set to NA to turn off filtering.
 #' @param k_score int How many neighbors (k) to use when scoring anchors
 
+options(error = rlang::entrace)
+
 # Dependencies
 library(SingleCellExperiment)
 library(Seurat)

--- a/openproblems/tasks/spatial_decomposition/methods/seuratv3.R
+++ b/openproblems/tasks/spatial_decomposition/methods/seuratv3.R
@@ -3,6 +3,8 @@
 #' @param sce_sp SingleCellExperiment spatial data
 #' @param n_pcs int Number of principal components
 
+options(error = rlang::entrace)
+
 library(Seurat)
 library(future)
 


### PR DESCRIPTION
When seurat fails, it gives no traceback, e.g. [here](https://github.com/openproblems-bio/openproblems/actions/runs/3205713057/jobs/5281423215) (due to being run as an external process.) This fixes that. 