### PR TITLE
sort matching rows after merge in cell cell comm

### DIFF
--- a/openproblems/tasks/_cell_cell_communication/_common/metrics/odds_ratio.py
+++ b/openproblems/tasks/_cell_cell_communication/_common/metrics/odds_ratio.py
@@ -8,10 +8,11 @@ import scipy.stats as stats
 def odds_ratio(adata, merge_keys, top_n=100):
     # Join benchmark (assumed truth) and ccc results
     # Get /w ccc_target and a response [0, 1] column
-    gt = adata.uns["ccc_target"].merge(
-        adata.uns["ccc_pred"], on=merge_keys, how="right"
+    gt = (
+        adata.uns["ccc_target"]
+        .merge(adata.uns["ccc_pred"], on=merge_keys, how="inner")
+        .sort_values("score", ascending=False)
     )
-    gt = gt[gt["response"].notna()]
 
     # assign the top rank interactions to 1
     a = np.zeros(len(gt["score"]))


### PR DESCRIPTION
@dbdimitrov why force methods to specify where or not the predictions are sorted when we can just sort them here?