### PR TITLE
make merge_keys available in adata.uns

### DIFF
--- a/openproblems/tasks/_cell_cell_communication/_common/api.py
+++ b/openproblems/tasks/_cell_cell_communication/_common/api.py
@@ -60,8 +60,9 @@ def check_dataset(adata, merge_keys):
     """Check that dataset output fits expected API."""
     assert "label" in adata.obs
     assert "ccc_target" in adata.uns
+
     assert "merge_keys" in adata.uns
-    assert adata.uns["merge_keys"] == merge_keys
+    np.testing.assert_array_equal(adata.uns["merge_keys"], merge_keys)
 
     # check target organism
     assert "target_organism" in adata.uns

--- a/openproblems/tasks/_cell_cell_communication/_common/api.py
+++ b/openproblems/tasks/_cell_cell_communication/_common/api.py
@@ -60,6 +60,8 @@ def check_dataset(adata, merge_keys):
     """Check that dataset output fits expected API."""
     assert "label" in adata.obs
     assert "ccc_target" in adata.uns
+    assert "merge_keys" in adata.uns
+    assert adata.uns["merge_keys"] == merge_keys
 
     # check target organism
     assert "target_organism" in adata.uns
@@ -185,6 +187,8 @@ def check_method(adata, merge_keys, is_baseline=False):
 def sample_dataset(merge_keys):
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()
+
+    adata.uns["merge_keys"] = merge_keys
 
     # keep only the top 10 most variable
     sc.pp.highly_variable_genes(adata, n_top_genes=len(SAMPLE_RECEPTOR_NAMES))

--- a/openproblems/tasks/_cell_cell_communication/cell_cell_communication_ligand_target/datasets/tnbc_wu2021.py
+++ b/openproblems/tasks/_cell_cell_communication/cell_cell_communication_ligand_target/datasets/tnbc_wu2021.py
@@ -21,6 +21,7 @@ def tnbc_data(test=False):
     adata = map_gene_symbols(
         adata, pathlib.Path(__file__).parent.joinpath("tnbc_wu2021_gene_symbols.csv")
     )
+    adata.uns["merge_keys"] = ["ligand", "target"]
     adata.uns["ligand_receptor_resource"] = ligand_receptor_resource(
         adata.uns["target_organism"]
     )

--- a/openproblems/tasks/_cell_cell_communication/cell_cell_communication_source_target/datasets/allen_brain_atlas.py
+++ b/openproblems/tasks/_cell_cell_communication/cell_cell_communication_source_target/datasets/allen_brain_atlas.py
@@ -15,6 +15,7 @@ from ..._common.utils import ligand_receptor_resource
 )
 def mouse_brain_atlas(test=False):
     adata = load_mouse_brain_atlas(test=test)
+    adata.uns["merge_keys"] = ["source", "target"]
     adata.uns["ligand_receptor_resource"] = ligand_receptor_resource(
         adata.uns["target_organism"]
     )


### PR DESCRIPTION
We need merge_keys available in adata in order to aggregate within methods.

Benchmark passing at https://github.com/scottgigante-immunai/openproblems/actions/runs/3323435471