### PR TITLE
break up _metrics into separate functions

### DIFF
--- a/openproblems/tasks/dimensionality_reduction/metrics/nn_ranking.py
+++ b/openproblems/tasks/dimensionality_reduction/metrics/nn_ranking.py
@@ -110,14 +110,8 @@ def _qnn(Q: np.ndarray, m: int) -> np.ndarray:  # pragma: no cover
     return QNN
 
 
-@njit(cache=True, fastmath=True)
-def _lcmc(QNN: np.ndarray, m: int) -> np.ndarray:  # pragma: no cover
-
-    LCMC = np.zeros(m)  # Local Continuity Meta Criterion
-
-    for k in range(m):
-        LCMC[k] = QNN[k] - (k + 1) / (m - 1)
-
+def _lcmc(QNN: np.ndarray, m: int) -> np.ndarray:
+    LCMC = QNN - (np.arange(m) + 1) / (m - 1)
     return LCMC
 
 


### PR DESCRIPTION
When _metrics fails, it is impossible to debug due to many computations being squashed into on NJIT function. This separates each metric into its own function, using NJIT when appropriate. See https://github.com/openproblems-bio/openproblems/actions/runs/3388609861/jobs/5633837315#step:19:2770

Passing benchmark at https://github.com/scottgigante-immunai/openproblems/actions/runs/3394490431