### PR TITLE
Add spectral baseline to dimensionality reduction

### DIFF
--- a/openproblems/tasks/dimensionality_reduction/methods/__init__.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/__init__.py
@@ -1,4 +1,5 @@
 from .baseline import high_dim_pca
+from .baseline import high_dim_spectral
 from .baseline import random_features
 from .densmap import densmap_logCPM_1kHVG
 from .densmap import densmap_pca_logCPM_1kHVG

--- a/openproblems/tasks/dimensionality_reduction/methods/baseline.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/baseline.py
@@ -41,3 +41,31 @@ def high_dim_pca(adata, n_comps: Optional[int] = None, test=False):
     adata.obsm["X_emb"] = adata.obsm["X_pca"]
     adata.uns["method_code_version"] = check_version("openproblems")
     return adata
+
+
+@method(
+    method_name="High-dimensional Laplacian Eigenmaps",
+    paper_name="High-dimensional Laplacian Eigenmaps (baseline)",
+    paper_url="https://openproblems.bio",
+    paper_year=2022,
+    code_url="https://github.com/openproblems-bio/openproblems",
+    is_baseline=True,
+)
+def high_dim_spectral(adata, n_comps: Optional[int] = None, test=False):
+    # We wanted to use all features, but output must be dense
+    # so this is a close approximation
+    import umap
+    import umap.spectral
+
+    if test:
+        n_comps = n_comps or 10
+    else:  # pragma: nocover
+        n_comps = n_comps or 200
+
+    graph = umap.UMAP(transform_mode="graph").fit_transform(adata.X)
+    adata.obsm["X_emb"] = umap.spectral.spectral_layout(
+        adata.X, graph, n_comps, random_state=None
+    )
+
+    adata.uns["method_code_version"] = check_version("openproblems")
+    return adata


### PR DESCRIPTION
The high-dimensional PCA does well in global metrics, but poorly in local knn metrics. This baseline (200-dimensional laplacian eigenmaps) should perform well with local knn ranking metrics.