### PR TITLE
make celltype clusters tighter in celltype random embedding/graph

### DIFF
--- a/openproblems/tasks/_batch_integration/batch_integration_graph/methods/baseline.py
+++ b/openproblems/tasks/_batch_integration/batch_integration_graph/methods/baseline.py
@@ -58,7 +58,7 @@ def _random_embedding(partition):
     embedding = OneHotEncoder().fit_transform(
         LabelEncoder().fit_transform(partition)[:, None]
     )
-    embedding = embedding + np.random.uniform(-0.1, 0.1, embedding.shape)
+    embedding = embedding + np.random.uniform(-0.01, 0.01, embedding.shape)
     return embedding
 
 


### PR DESCRIPTION
In immune_batch, the celltype random graph does not perform well on isolated labels F1, which is odd since it was designed for this task. The only explanation here is that louvain is combining clusters, which means the random noise is too large and thus clusters can be merged despite their clear separation. This should make the clusters tighter and thus less likely to be merged.