### PR TITLE
Make "Majority Vote" a baseline method

### DIFF
--- a/openproblems/tasks/label_projection/methods/baseline.py
+++ b/openproblems/tasks/label_projection/methods/baseline.py
@@ -10,6 +10,7 @@ import numpy as np
     paper_url="https://openproblems.bio",
     paper_year=2022,
     code_url="https://github.com/openproblems-bio/openproblems",
+    is_baseline=True,
 )
 def majority_vote(adata, test=False):
     majority = adata.obs.labels[adata.obs.is_train].value_counts().index[0]


### PR DESCRIPTION
I think `is_baseline` is meant to be set to True, given that nobody will actually use this type of approach in real life and call it a day. And also given that it's in the `baseline.py` file.

### Submission type

* [x] This submission fixes a bug
