### PR TITLE
Turn off ci skip

### DIFF
--- a/.github/workflows/process_results.yml
+++ b/.github/workflows/process_results.yml
@@ -161,7 +161,7 @@ jobs:
         path: './nbt2022-reproducibility'
         token: ${{ secrets.GH_ACTIONS_NBT_REPRODUCIBILITY_PAT }}
         author: "openproblems-bio <singlecellopenproblems@protonmail.com>"
-        commit-message: "Update benchmark results # ci skip"
+        commit-message: "Update benchmark results" # please don't skip ci ;)
 
     - name: AWS S3 cleanup
       if: "github.event_name == 'repository_dispatch'"

--- a/.github/workflows/process_results.yml
+++ b/.github/workflows/process_results.yml
@@ -134,7 +134,7 @@ jobs:
         path: './website'
         token: ${{ secrets.GH_ACTIONS_WEBSITE_PAT }}
         author: "openproblems-bio <singlecellopenproblems@protonmail.com>"
-        commit-message: "Update benchmark results # ci skip"
+        commit-message: "Update benchmark results"
 
     - name: Push to openproblems-bio/nbt2022-reproducibility
       if: |
@@ -161,7 +161,7 @@ jobs:
         path: './nbt2022-reproducibility'
         token: ${{ secrets.GH_ACTIONS_NBT_REPRODUCIBILITY_PAT }}
         author: "openproblems-bio <singlecellopenproblems@protonmail.com>"
-        commit-message: "Update benchmark results" # please don't skip ci ;)
+        commit-message: "Update benchmark results"
 
     - name: AWS S3 cleanup
       if: "github.event_name == 'repository_dispatch'"


### PR DESCRIPTION
I'd like to have the CI run so we know whether the quarto pages are being rendered properly on PR