### PR TITLE
add magic with reverse norm order

### DIFF
--- a/openproblems/tasks/denoising/methods/__init__.py
+++ b/openproblems/tasks/denoising/methods/__init__.py
@@ -6,3 +6,5 @@ from .knn_smoothing import knn_smoothing
 from .magic import knn_naive
 from .magic import magic
 from .magic import magic_approx
+from .magic import magic_approx_reverse_norm
+from .magic import magic_reverse_norm


### PR DESCRIPTION
Reversing the order of sqrt and libnorm inexplicably improves performance. Adding this to MAGIC with explicit naming so users are aware that this is different from defaults.