### PR TITLE
Changes in destVI code

### DIFF
--- a/openproblems/tasks/spatial_decomposition/methods/destvi.py
+++ b/openproblems/tasks/spatial_decomposition/methods/destvi.py
@@ -26,8 +26,8 @@ def destvi(
         max_epochs_sp = max_epochs_sp or 10
         max_epochs_sc = max_epochs_sc or 10
     else:  # pragma: nocover
-        max_epochs_sc = max_epochs_sc or 300
-        max_epochs_sp = max_epochs_sp or 2500
+        max_epochs_sc = max_epochs_sc or 500
+        max_epochs_sp = max_epochs_sp or 10000
 
     adata_sc, adata = split_sc_and_sp(adata)
 
@@ -36,15 +36,17 @@ def destvi(
     sc_model.train(
         max_epochs=max_epochs_sc,
         early_stopping=True,
-        early_stopping_monitor="reconstruction_loss_train",
+        train_size=0.9,
+        validation_size=0.1,
+        early_stopping_monitor="elbo_validation",
     )
     DestVI.setup_anndata(adata)
 
     st_model = DestVI.from_rna_model(adata, sc_model)
     st_model.train(
         max_epochs=max_epochs_sp,
-        early_stopping=True,
-        early_stopping_monitor="reconstruction_loss_train",
+        batch_size=min(int(adata.n_obs/20 + 3), 128),
+        plan_kwargs={'min_kl_weight': 3., 'max_kl_weight': 3}
     )
     adata.obsm["proportions_pred"] = st_model.get_proportions().to_numpy()
     adata.uns["method_code_version"] = check_version("scvi-tools")


### PR DESCRIPTION
This submission fixes a bug (link to related issue: https://github.com/openproblems-bio/openproblems/issues/821).
Increased number of epochs for condSCVI and destVI. Reduced mini-batch size as spatial data is quite small. Increased kl term which increases deconvolution for small datasets.