### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/datasets/loaders/multimodal/openproblems_neurips2021_bmmc/config.vsh.yaml
+++ b/src/datasets/loaders/multimodal/openproblems_neurips2021_bmmc/config.vsh.yaml
@@ -67,7 +67,7 @@ test_resources:
   #   path: /resources_test/common/openproblems_neurips2021/neurips2021_bmmc_cite.h5ad
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/loaders/multimodal/openproblems_neurips2022_pbmc/config.vsh.yaml
+++ b/src/datasets/loaders/multimodal/openproblems_neurips2022_pbmc/config.vsh.yaml
@@ -73,7 +73,7 @@ resources:
 #     path: /resources_test/common/openproblems_neurips2021/neurips2021_bmmc_cite.h5ad
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/loaders/multimodal/openproblems_v1_multimodal/config.vsh.yaml
+++ b/src/datasets/loaders/multimodal/openproblems_v1_multimodal/config.vsh.yaml
@@ -79,7 +79,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: apt
         packages: git

--- a/src/datasets/loaders/scrnaseq/cellxgene_census/config.vsh.yaml
+++ b/src/datasets/loaders/scrnaseq/cellxgene_census/config.vsh.yaml
@@ -157,7 +157,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    #image: openproblems/base_python:1.0.0
+    #image: openproblems/base_python:1
     image: python:3.11
     setup:
       - type: python

--- a/src/datasets/loaders/scrnaseq/cellxgene_census_from_source_h5ad/config.vsh.yaml
+++ b/src/datasets/loaders/scrnaseq/cellxgene_census_from_source_h5ad/config.vsh.yaml
@@ -113,7 +113,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    #image: openproblems/base_python:1.0.0
+    #image: openproblems/base_python:1
     image: python:3.11
     setup:
       - type: python

--- a/src/datasets/loaders/scrnaseq/openproblems_v1/config.vsh.yaml
+++ b/src/datasets/loaders/scrnaseq/openproblems_v1/config.vsh.yaml
@@ -75,7 +75,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: apt
         packages: git

--- a/src/datasets/loaders/spatial/zenodo/config.vsh.yaml
+++ b/src/datasets/loaders/spatial/zenodo/config.vsh.yaml
@@ -82,7 +82,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/loaders/spatial/zenodo_slidetags/config.vsh.yaml
+++ b/src/datasets/loaders/spatial/zenodo_slidetags/config.vsh.yaml
@@ -82,7 +82,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/normalization/atac_tfidf/config.vsh.yaml
+++ b/src/datasets/normalization/atac_tfidf/config.vsh.yaml
@@ -11,7 +11,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/datasets/normalization/l1_sqrt/config.vsh.yaml
+++ b/src/datasets/normalization/l1_sqrt/config.vsh.yaml
@@ -15,7 +15,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/datasets/normalization/log_cp/config.vsh.yaml
+++ b/src/datasets/normalization/log_cp/config.vsh.yaml
@@ -12,7 +12,7 @@ arguments:
     description: Number of counts per cell. When set to -1, will use None.
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/normalization/log_scran_pooling/config.vsh.yaml
+++ b/src/datasets/normalization/log_scran_pooling/config.vsh.yaml
@@ -7,7 +7,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [Matrix, rlang, scran, BiocParallel]

--- a/src/datasets/normalization/prot_clr/config.vsh.yaml
+++ b/src/datasets/normalization/prot_clr/config.vsh.yaml
@@ -15,7 +15,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/datasets/normalization/sqrt_cp/config.vsh.yaml
+++ b/src/datasets/normalization/sqrt_cp/config.vsh.yaml
@@ -11,7 +11,7 @@ arguments:
     description: Number of counts per cell
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/processors/hvg/config.vsh.yaml
+++ b/src/datasets/processors/hvg/config.vsh.yaml
@@ -6,7 +6,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/processors/knn/config.vsh.yaml
+++ b/src/datasets/processors/knn/config.vsh.yaml
@@ -6,7 +6,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/processors/pca/config.vsh.yaml
+++ b/src/datasets/processors/pca/config.vsh.yaml
@@ -10,7 +10,7 @@ resources:
   #   - path: "../../../resources_test/common/pancreas"
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/datasets/processors/subsample/config.vsh.yaml
+++ b/src/datasets/processors/subsample/config.vsh.yaml
@@ -42,7 +42,7 @@ test_resources:
   - path: /resources_test/common/pancreas
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     test_setup:
       - type: python
         packages:

--- a/src/datasets/processors/svd/config.vsh.yaml
+++ b/src/datasets/processors/svd/config.vsh.yaml
@@ -6,7 +6,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: [scikit-learn]

--- a/src/project/create_component/config.vsh.yaml
+++ b/src/project/create_component/config.vsh.yaml
@@ -51,7 +51,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     test_setup:
       - type: apt
         packages: git

--- a/src/project/render_readme/config.vsh.yaml
+++ b/src/project/render_readme/config.vsh.yaml
@@ -26,7 +26,7 @@ test_resources:
     path: test.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran:

--- a/src/project/upgrade_config/config.vsh.yaml
+++ b/src/project/upgrade_config/config.vsh.yaml
@@ -28,7 +28,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: ruamel.yaml

--- a/src/reporting/generate_qc/config.vsh.yaml
+++ b/src/reporting/generate_qc/config.vsh.yaml
@@ -41,7 +41,7 @@ test_resources:
     dest: resources_test/openproblems/task_results_v3
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/reporting/get_dataset_info/config.vsh.yaml
+++ b/src/reporting/get_dataset_info/config.vsh.yaml
@@ -26,7 +26,7 @@ test_resources:
     dest: resources_test/openproblems/task_results_v3
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ purrr, yaml, rlang, processx ]

--- a/src/reporting/get_method_info/config.vsh.yaml
+++ b/src/reporting/get_method_info/config.vsh.yaml
@@ -26,7 +26,7 @@ test_resources:
     dest: resources_test/openproblems/task_results_v3
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ purrr, yaml, rlang, processx ]

--- a/src/reporting/get_metric_info/config.vsh.yaml
+++ b/src/reporting/get_metric_info/config.vsh.yaml
@@ -26,7 +26,7 @@ test_resources:
     dest: resources_test/openproblems/task_results_v3
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ purrr, yaml, rlang, processx ]

--- a/src/reporting/get_results/config.vsh.yaml
+++ b/src/reporting/get_results/config.vsh.yaml
@@ -54,7 +54,7 @@ test_resources:
     dest: resources_test/openproblems/task_results_v3
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ purrr, yaml, rlang, dplyr, tidyr, readr, lubridate, dynutils, processx ]

--- a/src/reporting/get_task_info/config.vsh.yaml
+++ b/src/reporting/get_task_info/config.vsh.yaml
@@ -26,7 +26,7 @@ test_resources:
     dest: resources_test/openproblems/task_results_v3
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ purrr, yaml, rlang, processx ]

--- a/src/utils/extract_uns_metadata/config.vsh.yaml
+++ b/src/utils/extract_uns_metadata/config.vsh.yaml
@@ -34,7 +34,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     test_setup:
       - type: python
         packages: viashpy

--- a/src/utils/yaml_to_json/config.vsh.yaml
+++ b/src/utils/yaml_to_json/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/validation/check_dataset_with_schema/config.vsh.yaml
+++ b/src/validation/check_dataset_with_schema/config.vsh.yaml
@@ -36,7 +36,7 @@ test_resources:
     path: test.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     test_setup:
       - type: python
         packages: viashpy

--- a/src/validation/check_yaml_with_schema/config.vsh.yaml
+++ b/src/validation/check_yaml_with_schema/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.