### PR TITLE
Read the task commit from task_info.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
 
 ## Bug fixes
 
+- Read the task commit from `task_info.yaml` in `get_task_info`, instead of always writing a null (PR #943).
+
 - Fix metric direction (`maximize`/`minimize`) handling in `generate_qc` and `render_report` components of the `process_task_results` workflow (PR #936).
 
 - Fix bug in metric maximize handling and add raw scores table to the benchmark report (PR #937).

--- a/src/reporting/get_task_info/script.R
+++ b/src/reporting/get_task_info/script.R
@@ -42,7 +42,7 @@ cat("Using timestamp:", timestamp, "\n")
 cat("\n>>> Creating JSON list...\n")
 task_info_json <- list(
   name = jsonlite::unbox(sub("^task_", "", task_info_yaml$name)), # Remove "task_" prefix
-  commit = jsonlite::unbox(NA_character_), # TODO: Add when available in task_info.yaml
+  commit = jsonlite::unbox(task_info_yaml$commit %||% NA_character_),
   label = task_info_yaml$label %||%
     # Create label from task name if missing
     (


### PR DESCRIPTION
## Describe your changes

`get_task_info` hardcoded the commit, so every `task_info.json` we have ever
published carries `"commit": null`:

```r
commit = jsonlite::unbox(NA_character_), # TODO: Add when available in task_info.yaml
```

It now reads the field:

```r
commit = jsonlite::unbox(task_info_yaml$commit %||% NA_character_),
```

The `%||%` is there for the null rather than as a placeholder -- `unbox(NULL)`
serialises to `{}`, not `null`, so dropping it entirely would change the shape of
the output for every task that does not write the field yet:

```r
jsonlite::toJSON(list(commit = jsonlite::unbox(list()$commit)))
#> {"commit":{}}
jsonlite::toJSON(list(commit = jsonlite::unbox(list()$commit %||% NA_character_)))
#> {"commit":null}
```

A task that does not supply a commit keeps emitting `null`, which is exactly what it
does today -- no `"missing-sha"` placeholder, since a gap here should be fixed in
whatever generated the results rather than papered over.

The other half is in the task repos: `run_benchmark` has to write `workflow.commitId`
into `task_info.yaml`. openproblems-bio/task_spatial_simulators#33 does that, and I
will send the same to `task_template`.

## Issue ticket number and link
Closes #942

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes
  - [ ] Documentation

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!
